### PR TITLE
Add My Words page for students

### DIFF
--- a/lang_platform/urls.py
+++ b/lang_platform/urls.py
@@ -61,6 +61,7 @@ urlpatterns = [
     ),
     path("student-login/", views.student_login, name="student_login"),
     path("student-dashboard/", views.student_dashboard, name="student_dashboard"),
+    path("my-words/", views.my_words, name="my_words"),
     path('attach-vocabulary/<uuid:class_id>/', views.attach_vocab_list, name='attach_vocabulary'),
     path('view-vocabulary/<int:vocab_list_id>/', views.view_vocabulary, name='view_vocabulary'),
     path('attach-vocab-list/<int:vocab_list_id>/', views.attach_vocab_list, name='attach_vocab_list'),

--- a/learning/templates/learning/my_words.html
+++ b/learning/templates/learning/my_words.html
@@ -1,0 +1,21 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>My Words</title>
+</head>
+<body>
+    <h1>My Words</h1>
+    {% if words %}
+    <ul>
+        {% for word in words %}
+        <li>{{ word.word }} - {{ word.translation }}</li>
+        {% endfor %}
+    </ul>
+    {% else %}
+    <p>No words available.</p>
+    {% endif %}
+</body>
+</html>
+

--- a/learning/templates/learning/student_dashboard.html
+++ b/learning/templates/learning/student_dashboard.html
@@ -250,6 +250,7 @@
       <a href="#" data-pane="classes">My Classes</a>
       <a href="#" data-pane="assignments">My Assignments</a>
       <a href="#" data-pane="practice">Independent Practice</a>
+      <a href="{% url 'my_words' %}">My Words</a>
       <a href="{% url 'student_logout' %}" class="btn">Logout</a>
     </div>
   </div>

--- a/learning/views.py
+++ b/learning/views.py
@@ -559,6 +559,23 @@ def student_dashboard(request):
     })
 
 
+def my_words(request):
+    """Display all vocabulary words available to the logged-in student."""
+    student_id = request.session.get("student_id")
+    if not student_id:
+        return redirect("student_login")
+
+    student = get_object_or_404(Student, id=student_id)
+    words = VocabularyWord.objects.filter(
+        list__classes__in=student.classes.all()
+    ).distinct()
+
+    return render(request, "learning/my_words.html", {
+        "student": student,
+        "words": words,
+    })
+
+
 
 def student_logout(request):
     # Clear all session data


### PR DESCRIPTION
## Summary
- add `my-words/` route to serve a student's vocabulary words
- expose new "My Words" link on the student dashboard
- implement `my_words` view and basic template to list vocabulary

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b180be55b4832581dde0485cd1f772