### PR TITLE
Fix flashcard flipping to show translations

### DIFF
--- a/learning/templates/learning/assignment_modes/flashcard_mode_assignment.html
+++ b/learning/templates/learning/assignment_modes/flashcard_mode_assignment.html
@@ -48,6 +48,10 @@ body {
             align-items: center;
         }
 
+        .card .front {
+            transform: rotateY(0deg);
+        }
+
         .card .back {
             transform: rotateY(180deg);
             background-color: #e9ecef;

--- a/learning/templates/learning/flashcard_mode.html
+++ b/learning/templates/learning/flashcard_mode.html
@@ -75,6 +75,10 @@
       box-sizing: border-box;
     }
 
+    .card .front {
+      transform: rotateY(0deg);
+    }
+
     .card .back {
       transform: rotateY(180deg);
       background-color: #e9ecef;


### PR DESCRIPTION
## Summary
- Ensure flashcard front faces are hidden on flip so the back shows the translation.
- Apply consistent rotation styling to flashcard templates.

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68b4eef2a148832582243239b2ec8821