### PR TITLE
Add rotating practice session view

### DIFF
--- a/lang_platform/urls.py
+++ b/lang_platform/urls.py
@@ -69,6 +69,7 @@ urlpatterns = [
     path('flashcard-mode/<int:vocab_list_id>/', views.flashcard_mode, name='flashcard_mode'),
     path('match-up-mode/<int:vocab_list_id>/', views.match_up_mode, name='match_up_mode'),
     path('gap-fill-mode/<int:vocab_list_id>/', views.gap_fill_mode, name='gap_fill_mode'),
+    path('practice-session/<int:vocab_list_id>/', views.practice_session, name='practice_session'),
     path('practice/update_progress/', views.update_progress, name='update_progress'),
     path("lead-teacher-dashboard/", views.lead_teacher_dashboard, name="lead_teacher_dashboard"),
     path("lead-teacher-login/", views.lead_teacher_login, name="lead_teacher_login"),


### PR DESCRIPTION
## Summary
- Implement `practice_session` view to rotate through flashcard, typing, and match-up activities using a session-based queue of due words.
- Wire up new view in `lang_platform/urls.py`.

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b6684e68708325aad021455d4eeb94