### PR TITLE
Add practice session URL and update student dashboard

### DIFF
--- a/lang_platform/urls.py
+++ b/lang_platform/urls.py
@@ -69,6 +69,7 @@ urlpatterns = [
     path('flashcard-mode/<int:vocab_list_id>/', views.flashcard_mode, name='flashcard_mode'),
     path('match-up-mode/<int:vocab_list_id>/', views.match_up_mode, name='match_up_mode'),
     path('gap-fill-mode/<int:vocab_list_id>/', views.gap_fill_mode, name='gap_fill_mode'),
+    path('practice/<int:vocab_list_id>/', views.practice_session, name='practice_session'),
     path('practice/update_progress/', views.update_progress, name='update_progress'),
     path("lead-teacher-dashboard/", views.lead_teacher_dashboard, name="lead_teacher_dashboard"),
     path("lead-teacher-login/", views.lead_teacher_login, name="lead_teacher_login"),

--- a/learning/templates/learning/practice_session.html
+++ b/learning/templates/learning/practice_session.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Practice Session</title>
+</head>
+<body>
+    <h1>Practice Session for {{ vocab_list.name }}</h1>
+    <!-- Placeholder template for unified practice session -->
+</body>
+</html>

--- a/learning/templates/learning/student_dashboard.html
+++ b/learning/templates/learning/student_dashboard.html
@@ -354,14 +354,8 @@
                 <span class="arrow" style="font-size: 20px; font-weight: bold;">➡️</span>
                 <img src="{% static 'flags/'|add:vocab_list.target_language|add:'.png' %}" alt="{{ vocab_list.target_language }}" class="flag-icon" style="width: 30px; height: 30px; border-radius: 50%; box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);">
               </div>
-              <div class="practice-modes" style="display: flex; flex-wrap: wrap; justify-content: center; gap: 8px; margin-top: 10px;">
-                <a href="{% url 'flashcard_mode' vocab_list.id %}" class="btn mode-btn">Flashcards</a>
-                <a href="{% url 'match_up_mode' vocab_list.id %}" class="btn mode-btn">Match-Up</a>
-                <a href="{% url 'gap_fill_mode' vocab_list.id %}" class="btn mode-btn">Gap-Fill</a>
-                <a href="{% url 'destroy_the_wall' vocab_list.id %}" class="btn mode-btn">Destroy the Wall</a>
-                <a href="{% url 'unscramble_the_word' vocab_list.id %}" class="btn mode-btn">Unscramble</a>
-                <a href="{% url 'listening_dictation' vocab_list.id %}" class="btn mode-btn">Listening Dictation</a>
-                <a href="{% url 'listening_translation' vocab_list.id %}" class="btn mode-btn">Listening Translation</a>
+              <div class="practice-modes" style="display: flex; justify-content: center; margin-top: 10px;">
+                <a href="{% url 'practice_session' vocab_list.id %}" class="btn mode-btn">Practice</a>
               </div>
             </div>
           {% endfor %}

--- a/learning/views.py
+++ b/learning/views.py
@@ -726,6 +726,19 @@ def gap_fill_mode(request, vocab_list_id):
     })
 
 
+@student_login_required
+def practice_session(request, vocab_list_id):
+    """Unified practice session for a vocabulary list."""
+    vocab_list = get_object_or_404(VocabularyList, id=vocab_list_id)
+    student = get_object_or_404(Student, id=request.session.get("student_id"))
+    if not student.classes.filter(vocabulary_lists=vocab_list).exists():
+        return HttpResponseForbidden("You do not have access to this vocabulary list.")
+
+    return render(request, "learning/practice_session.html", {
+        "vocab_list": vocab_list,
+    })
+
+
 @csrf_exempt
 @require_POST
 def update_progress(request):


### PR DESCRIPTION
## Summary
- add dedicated `practice/<int:vocab_list_id>/` route for unified practice sessions
- replace legacy practice mode links on student dashboard with single practice session link
- implement placeholder practice session view and template

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68b6685020cc8325b416b73c200c9f09