### PR TITLE
Track score and trophies after practice interactions

### DIFF
--- a/learning/templates/learning/destroy_the_wall.html
+++ b/learning/templates/learning/destroy_the_wall.html
@@ -150,6 +150,8 @@
     const weeklyPointsEl = document.getElementById("weekly-points");
     const totalPointsEl = document.getElementById("total-points");
     const timeInModeEl = document.getElementById("time-in-mode");
+    const progressUrl = "{% url 'update_progress' %}";
+    const pointsUrl = "{% url 'update_points' %}";
 
     let sessionPoints = 0;
     let weeklyPoints = parseInt(weeklyPointsEl.textContent);
@@ -196,28 +198,49 @@
       brick.dataset.translation = word.translation;
 
       brick.addEventListener("click", () => {
-        // Check if the brick's translation matches the target
-        if (brick.dataset.translation === shuffledWords[currentWordIndex].translation) {
+        const isCorrect = brick.dataset.translation === shuffledWords[currentWordIndex].translation;
+
+        // Update progress then points sequentially
+        fetch(progressUrl, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-CSRFToken": getCSRFToken(),
+          },
+          body: JSON.stringify({
+            word_id: shuffledWords[currentWordIndex].id,
+            correct: isCorrect,
+          }),
+        })
+          .then(() =>
+            fetch(pointsUrl, {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                "X-CSRFToken": getCSRFToken(),
+              },
+              body: JSON.stringify({ points: isCorrect ? 1 : 0 }),
+            })
+          )
+          .then((res) => res.json())
+          .then((data) => {
+            if (data.success) {
+              sessionPoints += isCorrect ? 1 : 0;
+              sessionPointsEl.textContent = sessionPoints;
+              weeklyPoints = data.weekly_points;
+              totalPoints = data.total_points;
+              weeklyPointsEl.textContent = weeklyPoints;
+              totalPointsEl.textContent = totalPoints;
+              if (data.new_trophies && data.new_trophies.length > 0) {
+                alert("New trophies: " + data.new_trophies.join(", "));
+              }
+            }
+          })
+          .catch((err) => console.error("Error updating progress or points:", err));
+
+        if (isCorrect) {
           showFeedback("Correct!", "green");
           brick.style.visibility = "hidden";
-
-          // Update points
-          sessionPoints++;
-          weeklyPoints++;
-          totalPoints++;
-          sessionPointsEl.textContent = sessionPoints;
-          weeklyPointsEl.textContent = weeklyPoints;
-          totalPointsEl.textContent = totalPoints;
-
-          // Update points on the server
-          fetch("/update-points/", {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-              "X-CSRFToken": getCSRFToken(),
-            },
-            body: JSON.stringify({ points: 1 }),
-          }).catch(err => console.error("Error updating points:", err));
 
           // Wait 1 second before moving to the next target word
           setTimeout(() => {

--- a/learning/views.py
+++ b/learning/views.py
@@ -834,7 +834,7 @@ def update_points(request):
         student_id = request.session.get("student_id")
         points = data.get("points", 0)
 
-        if student_id and points:
+        if student_id is not None and points is not None:
             student = Student.objects.get(id=student_id)
             student.total_points += points
             student.weekly_points += points
@@ -844,9 +844,10 @@ def update_points(request):
             new_trophies = check_and_award_trophies(student)
 
             return JsonResponse({
-                "success": True, 
+                "success": True,
+                "weekly_points": student.weekly_points,
                 "total_points": student.total_points,
-                "new_trophies": new_trophies
+                "new_trophies": new_trophies,
             })
 
         else:


### PR DESCRIPTION
## Summary
- Return both weekly and total points plus newly earned trophies from `update_points`
- Destroy the Wall practice mode now posts progress and points sequentially and updates UI with server responses

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68b66851c6ac8325bb4c3a049821def6