### PR TITLE
Enhance practice session with styling and new activities

### DIFF
--- a/learning/templates/learning/practice_session.html
+++ b/learning/templates/learning/practice_session.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Practice Session - Pavonify</title>
+    <title>Practice Session - {{ vocab_list.name }}</title>
     <style>
         body {
             font-family: Arial, sans-serif;
@@ -17,27 +17,61 @@
             min-height: 100vh;
         }
         .pane {
-            background: #fff;
-            border-radius: 8px;
+            background: #fec10e;
+            border-radius: 10px;
             box-shadow: 0 2px 4px rgba(0,0,0,0.1);
             padding: 20px;
             width: 100%;
             max-width: 600px;
+            color: #fff;
+            position: relative;
         }
         .pane h1 {
             margin-top: 0;
-            color: #0aa2ef;
             text-align: center;
         }
         #activity-container {
             margin-top: 20px;
             text-align: center;
         }
+        .back-button {
+            position: absolute;
+            top: 10px;
+            left: 10px;
+            background: #086baf;
+            color: #fff;
+            border: none;
+            border-radius: 5px;
+            padding: 8px 12px;
+            cursor: pointer;
+        }
+        .back-button:hover {
+            background: #065f93;
+        }
+        .shimmer {
+            position: relative;
+            overflow: hidden;
+        }
+        .shimmer::after {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: -100%;
+            width: 100%;
+            height: 100%;
+            background: linear-gradient(90deg, rgba(255,255,255,0) 0%, rgba(255,255,255,0.4) 50%, rgba(255,255,255,0) 100%);
+            animation: shimmer 1.5s infinite;
+        }
+        @keyframes shimmer {
+            0% { left: -100%; }
+            100% { left: 100%; }
+        }
     </style>
 </head>
 <body>
 <div class="pane">
-    <h1>Practice Session</h1>
+    <button class="back-button" onclick="window.history.back()">Back</button>
+    <h1>Practice Session - {{ vocab_list.name }}</h1>
     <p><strong>Session Points:</strong> <span id="session-points">0</span></p>
     <div id="activity-container"></div>
 </div>
@@ -70,18 +104,53 @@
         }
 
         switch (activity.type) {
+            case 'show_word':
+                renderShowWord(activity);
+                break;
             case 'flashcard':
                 renderFlashcard(activity);
+                break;
+            case 'shimmer':
+                renderShimmer(activity);
                 break;
             case 'typing':
                 renderTyping(activity);
                 break;
-            case 'match':
-                renderMatchUp(activity);
+            case 'fill_gaps':
+                renderFillGaps(activity);
+                break;
+            case 'multiple_choice':
+                renderMultipleChoice(activity);
+                break;
+            case 'true_false':
+                renderTrueFalse(activity);
                 break;
             default:
                 container.innerHTML = '<p>Unknown activity type.</p>';
         }
+    }
+
+    function renderShowWord(activity) {
+        const container = document.getElementById('activity-container');
+        container.innerHTML = `
+            <div class="show-word">
+                <p>${activity.prompt}</p>
+                <button id="reveal-word">Show Word</button>
+                <div id="revealed-word" style="display:none; margin-top:10px;">${activity.answer}</div>
+                <div style="margin-top:10px;">
+                    <button id="show-word-next" style="display:none;">Next</button>
+                </div>
+            </div>
+        `;
+
+        document.getElementById('reveal-word').addEventListener('click', () => {
+            document.getElementById('revealed-word').style.display = 'block';
+            document.getElementById('show-word-next').style.display = 'inline-block';
+        });
+
+        document.getElementById('show-word-next').addEventListener('click', () => {
+            submitResponse(activity.word_id, true);
+        });
     }
 
     function renderFlashcard(activity) {
@@ -107,6 +176,21 @@
         });
     }
 
+    function renderShimmer(activity) {
+        const container = document.getElementById('activity-container');
+        container.innerHTML = `
+            <div class="shimmer-card">
+                <p class="shimmer">${activity.prompt}</p>
+                <p class="shimmer">${activity.answer}</p>
+                <button id="shimmer-next">Next</button>
+            </div>
+        `;
+
+        document.getElementById('shimmer-next').addEventListener('click', () => {
+            submitResponse(activity.word_id, true);
+        });
+    }
+
     function renderTyping(activity) {
         const container = document.getElementById('activity-container');
         container.innerHTML = `
@@ -123,10 +207,27 @@
         });
     }
 
-    function renderMatchUp(activity) {
+    function renderFillGaps(activity) {
         const container = document.getElementById('activity-container');
         container.innerHTML = `
-            <div class="match-up">
+            <div class="fill-gaps">
+                <p>${activity.translation}</p>
+                <p>${activity.prompt}</p>
+                <input type="text" id="fill-gaps-input" />
+                <button id="fill-gaps-submit">Submit</button>
+            </div>
+        `;
+        document.getElementById('fill-gaps-submit').addEventListener('click', () => {
+            const answer = document.getElementById('fill-gaps-input').value;
+            const correct = answer.trim().toLowerCase() === (activity.answer || '').toLowerCase();
+            submitResponse(activity.word_id, correct, answer);
+        });
+    }
+
+    function renderMultipleChoice(activity) {
+        const container = document.getElementById('activity-container');
+        container.innerHTML = `
+            <div class="multiple-choice">
                 <p>${activity.prompt}</p>
                 <div id="match-options">
                     ${activity.options.map(opt => `<button class="match-option">${opt}</button>`).join('')}
@@ -139,6 +240,23 @@
                 const correct = selected === String(activity.answer);
                 submitResponse(activity.word_id, correct, selected);
             });
+        });
+    }
+
+    function renderTrueFalse(activity) {
+        const container = document.getElementById('activity-container');
+        container.innerHTML = `
+            <div class="true-false">
+                <p>${activity.prompt} - ${activity.shown_translation}</p>
+                <button id="true-btn">True</button>
+                <button id="false-btn">False</button>
+            </div>
+        `;
+        document.getElementById('true-btn').addEventListener('click', () => {
+            submitResponse(activity.word_id, activity.answer === true);
+        });
+        document.getElementById('false-btn').addEventListener('click', () => {
+            submitResponse(activity.word_id, activity.answer === false);
         });
     }
 

--- a/learning/views.py
+++ b/learning/views.py
@@ -659,7 +659,15 @@ def practice_session(request, vocab_list_id):
 
     queue_key = f"practice_queue_{vocab_list_id}"
     queue = request.session.get(queue_key, [])
-    activities = ["flashcard", "typing", "match"]
+    activities = [
+        "show_word",
+        "flashcard",
+        "shimmer",
+        "typing",
+        "fill_gaps",
+        "multiple_choice",
+        "true_false",
+    ]
 
     def _init_queue():
         words = get_due_words(student, vocab_list, limit=20)
@@ -671,17 +679,33 @@ def practice_session(request, vocab_list_id):
         if not queue:
             return JsonResponse({"completed": True})
 
-        item = queue.pop(0)
+        item = queue[0]
         word = VocabularyWord.objects.get(id=item["id"])
         activity = activities[item["step"]]
 
         if item["step"] + 1 < len(activities):
-            queue.append({"id": item["id"], "step": item["step"] + 1})
+            queue[0]["step"] += 1
+        else:
+            queue.pop(0)
         request.session[queue_key] = queue
 
-        if activity == "flashcard":
+        if activity == "show_word":
+            payload = {
+                "type": "show_word",
+                "word_id": word.id,
+                "prompt": word.translation,
+                "answer": word.word,
+            }
+        elif activity == "flashcard":
             payload = {
                 "type": "flashcard",
+                "word_id": word.id,
+                "prompt": word.word,
+                "answer": word.translation,
+            }
+        elif activity == "shimmer":
+            payload = {
+                "type": "shimmer",
                 "word_id": word.id,
                 "prompt": word.word,
                 "answer": word.translation,
@@ -693,7 +717,21 @@ def practice_session(request, vocab_list_id):
                 "prompt": word.word,
                 "answer": word.translation,
             }
-        else:  # match (multiple choice)
+        elif activity == "fill_gaps":
+            masked = list(word.word)
+            indices = list(range(len(masked)))
+            random.shuffle(indices)
+            for i in indices[: len(masked) // 2]:
+                if masked[i].isalpha():
+                    masked[i] = "_"
+            payload = {
+                "type": "fill_gaps",
+                "word_id": word.id,
+                "prompt": "".join(masked),
+                "translation": word.translation,
+                "answer": word.word,
+            }
+        elif activity == "multiple_choice":
             translations = list(
                 VocabularyWord.objects.filter(list=vocab_list)
                 .exclude(id=word.id)
@@ -703,12 +741,30 @@ def practice_session(request, vocab_list_id):
             options = translations[:3] + [word.translation]
             random.shuffle(options)
             payload = {
-                "type": "match",
+                "type": "multiple_choice",
                 "word_id": word.id,
                 "prompt": word.word,
                 "options": options,
                 "answer": word.translation,
             }
+        elif activity == "true_false":
+            translations = list(
+                VocabularyWord.objects.filter(list=vocab_list)
+                .exclude(id=word.id)
+                .values_list("translation", flat=True)
+            )
+            shown = word.translation
+            if translations and random.choice([True, False]):
+                shown = random.choice(translations)
+            payload = {
+                "type": "true_false",
+                "word_id": word.id,
+                "prompt": word.word,
+                "shown_translation": shown,
+                "answer": shown == word.translation,
+            }
+        else:
+            payload = {"type": "unknown"}
         return JsonResponse(payload)
 
     if not queue:


### PR DESCRIPTION
## Summary
- Style practice session pane, add back button, and show vocab list name in the title.
- Introduce additional activity types such as show-word exposure, shimmer cards, fill-the-gap, multiple choice, and true/false.
- Expand server-side logic to serve the new activity payloads.

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django'; dependencies could not be installed due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68b6859d2acc83258a1b9dcf02f8153c