### PR TITLE
Enhance practice session with styling and new activities

### DIFF
--- a/learning/templates/learning/practice_session.html
+++ b/learning/templates/learning/practice_session.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Practice Session - Pavonify</title>
+    <title>Practice Session - {{ vocab_list.name }}</title>
     <style>
         body {
             font-family: Arial, sans-serif;
@@ -17,27 +17,101 @@
             min-height: 100vh;
         }
         .pane {
-            background: #fff;
-            border-radius: 8px;
+            background: #fec10e;
+            border-radius: 10px;
             box-shadow: 0 2px 4px rgba(0,0,0,0.1);
             padding: 20px;
             width: 100%;
             max-width: 600px;
+            color: #fff;
+            position: relative;
         }
-        .pane h1 {
-            margin-top: 0;
-            color: #0aa2ef;
+        .pane-header {
+            display: flex;
+            align-items: center;
+            margin-bottom: 10px;
+        }
+        .pane-header h1 {
+            flex: 1;
             text-align: center;
+            margin: 0;
         }
         #activity-container {
             margin-top: 20px;
             text-align: center;
         }
+        .pane button {
+            background: #086baf;
+            color: #fff;
+            border: none;
+            border-radius: 5px;
+            padding: 8px 12px;
+            cursor: pointer;
+            margin: 4px;
+        }
+        .pane button:hover {
+            background: #065f93;
+        }
+        .back-button {
+            margin-right: 10px;
+        }
+        .back-button:hover {
+            background: #065f93;
+        }
+        .shimmer {
+            position: relative;
+            overflow: hidden;
+        }
+        .shimmer::after {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: -100%;
+            width: 100%;
+            height: 100%;
+            background: linear-gradient(90deg, rgba(255,255,255,0) 0%, rgba(255,255,255,0.4) 50%, rgba(255,255,255,0) 100%);
+            animation: shimmer 1.5s infinite;
+        }
+        @keyframes shimmer {
+            0% { left: -100%; }
+            100% { left: 100%; }
+        }
+        .mini-match {
+            display: flex;
+            justify-content: center;
+            gap: 40px;
+            margin-top: 20px;
+        }
+        .mini-match .column {
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+        }
+        .mini-match .tile,
+        .mini-match .target {
+            width: 120px;
+            height: 50px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: #f8f9fa;
+            color: #000;
+            border: 1px solid #ccc;
+            cursor: pointer;
+        }
+        .mini-match .target.correct {
+            background: #28a745;
+            color: #fff;
+            font-weight: bold;
+        }
     </style>
 </head>
 <body>
 <div class="pane">
-    <h1>Practice Session</h1>
+    <div class="pane-header">
+        <button class="back-button" onclick="window.history.back()">Back</button>
+        <h1>Practice Session - {{ vocab_list.name }}</h1>
+    </div>
     <p><strong>Session Points:</strong> <span id="session-points">0</span></p>
     <div id="activity-container"></div>
 </div>
@@ -70,18 +144,56 @@
         }
 
         switch (activity.type) {
+            case 'show_word':
+                renderShowWord(activity);
+                break;
             case 'flashcard':
                 renderFlashcard(activity);
+                break;
+            case 'shimmer':
+                renderShimmer(activity);
                 break;
             case 'typing':
                 renderTyping(activity);
                 break;
-            case 'match':
-                renderMatchUp(activity);
+            case 'fill_gaps':
+                renderFillGaps(activity);
+                break;
+            case 'multiple_choice':
+                renderMultipleChoice(activity);
+                break;
+            case 'true_false':
+                renderTrueFalse(activity);
+                break;
+            case 'mini_match':
+                renderMiniMatch(activity);
                 break;
             default:
                 container.innerHTML = '<p>Unknown activity type.</p>';
         }
+    }
+
+    function renderShowWord(activity) {
+        const container = document.getElementById('activity-container');
+        container.innerHTML = `
+            <div class="show-word">
+                <p>${activity.prompt}</p>
+                <button id="reveal-word">Show Word</button>
+                <div id="revealed-word" style="display:none; margin-top:10px;">${activity.answer}</div>
+                <div style="margin-top:10px;">
+                    <button id="show-word-next" style="display:none;">Next</button>
+                </div>
+            </div>
+        `;
+
+        document.getElementById('reveal-word').addEventListener('click', () => {
+            document.getElementById('revealed-word').style.display = 'block';
+            document.getElementById('show-word-next').style.display = 'inline-block';
+        });
+
+        document.getElementById('show-word-next').addEventListener('click', () => {
+            submitResponse(activity.word_id, true).then(fetchActivity);
+        });
     }
 
     function renderFlashcard(activity) {
@@ -103,7 +215,22 @@
         });
 
         document.getElementById('flashcard-done').addEventListener('click', () => {
-            submitResponse(activity.word_id, true);
+            submitResponse(activity.word_id, true).then(fetchActivity);
+        });
+    }
+
+    function renderShimmer(activity) {
+        const container = document.getElementById('activity-container');
+        container.innerHTML = `
+            <div class="shimmer-card">
+                <p class="shimmer">${activity.prompt}</p>
+                <p class="shimmer">${activity.answer}</p>
+                <button id="shimmer-next">Next</button>
+            </div>
+        `;
+
+        document.getElementById('shimmer-next').addEventListener('click', () => {
+            submitResponse(activity.word_id, true).then(fetchActivity);
         });
     }
 
@@ -119,14 +246,35 @@
         document.getElementById('typing-submit').addEventListener('click', () => {
             const answer = document.getElementById('typing-input').value;
             const correct = answer.trim().toLowerCase() === (activity.answer || '').toLowerCase();
-            submitResponse(activity.word_id, correct, answer);
+            submitResponse(activity.word_id, correct).then(() => {
+                showResult(correct, activity.answer);
+            });
         });
     }
 
-    function renderMatchUp(activity) {
+    function renderFillGaps(activity) {
         const container = document.getElementById('activity-container');
         container.innerHTML = `
-            <div class="match-up">
+            <div class="fill-gaps">
+                <p>${activity.translation}</p>
+                <p>${activity.prompt}</p>
+                <input type="text" id="fill-gaps-input" />
+                <button id="fill-gaps-submit">Submit</button>
+            </div>
+        `;
+        document.getElementById('fill-gaps-submit').addEventListener('click', () => {
+            const answer = document.getElementById('fill-gaps-input').value;
+            const correct = answer.trim().toLowerCase() === (activity.answer || '').toLowerCase();
+            submitResponse(activity.word_id, correct).then(() => {
+                showResult(correct, activity.answer);
+            });
+        });
+    }
+
+    function renderMultipleChoice(activity) {
+        const container = document.getElementById('activity-container');
+        container.innerHTML = `
+            <div class="multiple-choice">
                 <p>${activity.prompt}</p>
                 <div id="match-options">
                     ${activity.options.map(opt => `<button class="match-option">${opt}</button>`).join('')}
@@ -137,12 +285,83 @@
             btn.addEventListener('click', (e) => {
                 const selected = e.target.textContent;
                 const correct = selected === String(activity.answer);
-                submitResponse(activity.word_id, correct, selected);
+                submitResponse(activity.word_id, correct).then(() => {
+                    showResult(correct, activity.answer);
+                });
             });
         });
     }
 
-    async function submitResponse(wordId, correct, answer=null) {
+    function renderTrueFalse(activity) {
+        const container = document.getElementById('activity-container');
+        container.innerHTML = `
+            <div class="true-false">
+                <p>${activity.prompt} - ${activity.shown_translation}</p>
+                <button id="true-btn">True</button>
+                <button id="false-btn">False</button>
+            </div>
+        `;
+        document.getElementById('true-btn').addEventListener('click', () => {
+            const correct = activity.answer === true;
+            submitResponse(activity.word_id, correct).then(() => {
+                showResult(correct, activity.answer ? 'True' : 'False');
+            });
+        });
+        document.getElementById('false-btn').addEventListener('click', () => {
+            const correct = activity.answer === false;
+            submitResponse(activity.word_id, correct).then(() => {
+                showResult(correct, activity.answer ? 'True' : 'False');
+            });
+        });
+    }
+
+    function renderMiniMatch(activity) {
+        const container = document.getElementById('activity-container');
+        container.innerHTML = `
+            <div class="mini-match">
+                <div class="column" id="mini-source">
+                    ${activity.words.map(w => `<div class="tile" draggable="true" data-word="${w}">${w}</div>`).join('')}
+                </div>
+                <div class="column" id="mini-target">
+                    ${activity.translations.map(t => `<div class="target" data-translation="${t}">${t}</div>`).join('')}
+                </div>
+            </div>
+        `;
+
+        const pairs = activity.pairs;
+        let matches = 0;
+        container.querySelectorAll('.tile').forEach(tile => {
+            tile.addEventListener('dragstart', e => {
+                e.dataTransfer.setData('text/plain', tile.dataset.word);
+            });
+        });
+        container.querySelectorAll('.target').forEach(target => {
+            target.addEventListener('dragover', e => e.preventDefault());
+            target.addEventListener('drop', e => {
+                e.preventDefault();
+                const word = e.dataTransfer.getData('text/plain');
+                const translation = target.dataset.translation;
+                if (pairs[word] === translation) {
+                    target.classList.add('correct');
+                    target.textContent = word + ' - ' + translation;
+                    const dragged = container.querySelector(`.tile[data-word="${word}"]`);
+                    if (dragged) dragged.style.visibility = 'hidden';
+                    matches += 1;
+                    if (matches === activity.words.length) {
+                        submitResponse(activity.word_id, true).then(() => {
+                            showResult(true, 'All matched!');
+                        });
+                    }
+                } else {
+                    submitResponse(activity.word_id, false).then(() => {
+                        showResult(false, translation);
+                    });
+                }
+            });
+        });
+    }
+
+    async function submitResponse(wordId, correct) {
         try {
             await fetch("{% url 'update_progress' %}", {
                 method: 'POST',
@@ -166,12 +385,17 @@
                 sessionPoints += 5;
                 document.getElementById('session-points').textContent = sessionPoints;
             }
-
-            // Fetch next activity
-            await fetchActivity();
         } catch (error) {
             console.error('Failed to submit response:', error);
         }
+    }
+
+    function showResult(correct, correctAnswer) {
+        const container = document.getElementById('activity-container');
+        container.innerHTML =
+            `<p>${correct ? 'Correct!' : 'Incorrect. Correct answer: ' + correctAnswer}</p>` +
+            `<button id="next-activity">Next</button>`;
+        document.getElementById('next-activity').addEventListener('click', fetchActivity);
     }
 
     function getCookie(name) {

--- a/learning/templates/learning/practice_session.html
+++ b/learning/templates/learning/practice_session.html
@@ -26,13 +26,8 @@
             color: #fff;
             position: relative;
         }
-        .pane-header {
-            display: flex;
-            align-items: center;
-            margin-bottom: 10px;
-        }
-        .pane-header h1 {
-            flex: 1;
+        .pane h1 {
+            margin-top: 0;
             text-align: center;
             margin: 0;
         }
@@ -53,7 +48,9 @@
             background: #065f93;
         }
         .back-button {
-            margin-right: 10px;
+            position: absolute;
+            top: 10px;
+            left: 10px;
         }
         .back-button:hover {
             background: #065f93;
@@ -108,10 +105,8 @@
 </head>
 <body>
 <div class="pane">
-    <div class="pane-header">
-        <button class="back-button" onclick="window.history.back()">Back</button>
-        <h1>Practice Session - {{ vocab_list.name }}</h1>
-    </div>
+    <button class="back-button" onclick="window.history.back()">Back</button>
+    <h1>Practice Session - {{ vocab_list.name }}</h1>
     <p><strong>Session Points:</strong> <span id="session-points">0</span></p>
     <div id="activity-container"></div>
 </div>

--- a/learning/views.py
+++ b/learning/views.py
@@ -659,7 +659,8 @@ def practice_session(request, vocab_list_id):
 
     queue_key = f"practice_queue_{vocab_list_id}"
     queue = request.session.get(queue_key, [])
-    activities = ["flashcard", "typing", "match"]
+    exposure_activities = ["show_word", "flashcard", "shimmer"]
+    testing_activities = ["typing", "fill_gaps", "multiple_choice", "true_false", "mini_match"]
 
     def _init_queue():
         words = get_due_words(student, vocab_list, limit=20)
@@ -671,17 +672,33 @@ def practice_session(request, vocab_list_id):
         if not queue:
             return JsonResponse({"completed": True})
 
-        item = queue.pop(0)
+        item = queue[0]
         word = VocabularyWord.objects.get(id=item["id"])
-        activity = activities[item["step"]]
-
-        if item["step"] + 1 < len(activities):
-            queue.append({"id": item["id"], "step": item["step"] + 1})
+        if item["step"] == 0:
+            activity = random.choice(exposure_activities)
+            queue[0]["step"] = 1
+        else:
+            activity = random.choice(testing_activities)
+            queue.pop(0)
         request.session[queue_key] = queue
 
-        if activity == "flashcard":
+        if activity == "show_word":
+            payload = {
+                "type": "show_word",
+                "word_id": word.id,
+                "prompt": word.translation,
+                "answer": word.word,
+            }
+        elif activity == "flashcard":
             payload = {
                 "type": "flashcard",
+                "word_id": word.id,
+                "prompt": word.word,
+                "answer": word.translation,
+            }
+        elif activity == "shimmer":
+            payload = {
+                "type": "shimmer",
                 "word_id": word.id,
                 "prompt": word.word,
                 "answer": word.translation,
@@ -693,7 +710,21 @@ def practice_session(request, vocab_list_id):
                 "prompt": word.word,
                 "answer": word.translation,
             }
-        else:  # match (multiple choice)
+        elif activity == "fill_gaps":
+            masked = list(word.word)
+            indices = list(range(len(masked)))
+            random.shuffle(indices)
+            for i in indices[: len(masked) // 2]:
+                if masked[i].isalpha():
+                    masked[i] = "_"
+            payload = {
+                "type": "fill_gaps",
+                "word_id": word.id,
+                "prompt": "".join(masked),
+                "translation": word.translation,
+                "answer": word.word,
+            }
+        elif activity == "multiple_choice":
             translations = list(
                 VocabularyWord.objects.filter(list=vocab_list)
                 .exclude(id=word.id)
@@ -703,12 +734,48 @@ def practice_session(request, vocab_list_id):
             options = translations[:3] + [word.translation]
             random.shuffle(options)
             payload = {
-                "type": "match",
+                "type": "multiple_choice",
                 "word_id": word.id,
                 "prompt": word.word,
                 "options": options,
                 "answer": word.translation,
             }
+        elif activity == "mini_match":
+            others = list(
+                VocabularyWord.objects.filter(list=vocab_list).exclude(id=word.id)
+            )
+            random.shuffle(others)
+            selected = [word] + others[:3]
+            pairs = {w.word: w.translation for w in selected}
+            words_list = [w.word for w in selected]
+            translations = [w.translation for w in selected]
+            random.shuffle(words_list)
+            random.shuffle(translations)
+            payload = {
+                "type": "mini_match",
+                "word_id": word.id,
+                "words": words_list,
+                "translations": translations,
+                "pairs": pairs,
+            }
+        elif activity == "true_false":
+            translations = list(
+                VocabularyWord.objects.filter(list=vocab_list)
+                .exclude(id=word.id)
+                .values_list("translation", flat=True)
+            )
+            shown = word.translation
+            if translations and random.choice([True, False]):
+                shown = random.choice(translations)
+            payload = {
+                "type": "true_false",
+                "word_id": word.id,
+                "prompt": word.word,
+                "shown_translation": shown,
+                "answer": shown == word.translation,
+            }
+        else:
+            payload = {"type": "unknown"}
         return JsonResponse(payload)
 
     if not queue:


### PR DESCRIPTION
## Summary
- Style practice session pane and buttons, including back button placement and vocab list title.
- Randomly alternate one exposure and one testing activity per word and show correctness feedback.
- Add a drag-and-drop mini match-up testing activity.

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b6859d2acc83258a1b9dcf02f8153c