### PR TITLE
Add weekly and monthly categories to class leaderboards

### DIFF
--- a/learning/templates/learning/class_leaderboard.html
+++ b/learning/templates/learning/class_leaderboard.html
@@ -133,6 +133,14 @@
   <!-- Leaderboard Pane -->
   <div class="pane">
     <h2>Leaderboard for {{ class_instance.name }}</h2>
+    <div class="category-select" style="margin-bottom: 10px;">
+      <label for="category-select">Category:</label>
+      <select id="category-select">
+        <option value="total_points" {% if current_category == 'total_points' %}selected{% endif %}>Total Points</option>
+        <option value="monthly_points" {% if current_category == 'monthly_points' %}selected{% endif %}>Monthly Points</option>
+        <option value="weekly_points" {% if current_category == 'weekly_points' %}selected{% endif %}>Weekly Points</option>
+      </select>
+    </div>
     <div id="leaderboard-container">
       {% include "learning/leaderboard_fragment.html" %}
     </div>
@@ -144,6 +152,8 @@
     const refreshIntervalInput = document.getElementById("refresh-interval");
     const setRefreshButton = document.getElementById("set-refresh");
     const leaderboardContainer = document.getElementById("leaderboard-container");
+    const categorySelect = document.getElementById("category-select");
+    let currentCategory = "{{ current_category }}";
 
     // Default refresh interval (in milliseconds)
     let refreshInterval = parseInt(refreshIntervalInput.value) * 1000;
@@ -157,7 +167,7 @@
     }
 
     function refreshLeaderboard() {
-      fetch("{% url 'refresh_leaderboard' class_instance.id %}")
+      fetch(`{% url 'refresh_leaderboard' class_instance.id %}?category=${currentCategory}`)
         .then(response => response.text())
         .then(html => {
           leaderboardContainer.innerHTML = html;
@@ -175,6 +185,11 @@
       }
       refreshInterval = intervalValue * 1000;
       startRefreshTimer();
+    });
+
+    categorySelect.addEventListener("change", () => {
+      currentCategory = categorySelect.value;
+      refreshLeaderboard();
     });
 
     // Start the timer with the default interval when the page loads.

--- a/learning/templates/learning/leaderboard_fragment.html
+++ b/learning/templates/learning/leaderboard_fragment.html
@@ -3,7 +3,7 @@
     <tr>
       <th>Rank</th>
       <th>Student Name</th>
-      <th>Total Points</th>
+      <th>{{ column_label }}</th>
     </tr>
   </thead>
   <tbody>
@@ -21,7 +21,15 @@
         {% endif %}
       </td>
       <td>{{ student.first_name }} {{ student.last_name }}</td>
-      <td>{{ student.total_points }} pts</td>
+      <td>
+        {% if current_category == "weekly_points" %}
+          {{ student.weekly_points }} pts
+        {% elif current_category == "monthly_points" %}
+          {{ student.monthly_points }} pts
+        {% else %}
+          {{ student.total_points }} pts
+        {% endif %}
+      </td>
     </tr>
     {% empty %}
     <tr>

--- a/learning/views.py
+++ b/learning/views.py
@@ -2095,13 +2095,22 @@ def class_leaderboard(request, class_id):
     class_instance = get_object_or_404(Class, id=class_id)
     if request.user not in class_instance.teachers.all():
         return HttpResponseForbidden("You do not have permission to view this class leaderboard.")
-    
-    # Get all students in the class, ordered by total_points descending.
-    students = class_instance.students.all().order_by('-total_points')
-    
+    category = request.GET.get("category", "total_points")
+    if category not in {"total_points", "weekly_points", "monthly_points"}:
+        category = "total_points"
+
+    students = class_instance.students.all().order_by(f"-{category}")
+    column_labels = {
+        "total_points": "Total Points",
+        "weekly_points": "Weekly Points",
+        "monthly_points": "Monthly Points",
+    }
+
     context = {
         "class_instance": class_instance,
         "students": students,
+        "current_category": category,
+        "column_label": column_labels[category],
     }
     return render(request, "learning/class_leaderboard.html", context)
 
@@ -2111,12 +2120,22 @@ def refresh_leaderboard(request, class_id):
     class_instance = get_object_or_404(Class, id=class_id)
     if request.user not in class_instance.teachers.all():
         return HttpResponseForbidden("You do not have permission to view this class leaderboard.")
-    
-    students = class_instance.students.all().order_by('-total_points')
-    
+    category = request.GET.get("category", "total_points")
+    if category not in {"total_points", "weekly_points", "monthly_points"}:
+        category = "total_points"
+
+    students = class_instance.students.all().order_by(f"-{category}")
+    column_labels = {
+        "total_points": "Total Points",
+        "weekly_points": "Weekly Points",
+        "monthly_points": "Monthly Points",
+    }
+
     return render(request, "learning/leaderboard_fragment.html", {
          "class_instance": class_instance,
          "students": students,
+         "current_category": category,
+         "column_label": column_labels[category],
     })
 
 


### PR DESCRIPTION
## Summary
- Allow teachers to view class leaderboards by total, weekly, or monthly points
- Update leaderboard fragment to display points for selected category
- Add UI and JS to switch leaderboard categories with auto-refresh support

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68b94d549fc483259e27d6c077cb493c