### PR TITLE
Fix Stripe upgrade checkout and webhook API key

### DIFF
--- a/learning/templates/learning/teacher_dashboard.html
+++ b/learning/templates/learning/teacher_dashboard.html
@@ -812,8 +812,8 @@ a.btn:hover, button.btn:hover {
               },
           });
           const data = await response.json();
-          if (data.sessionId) {
-              window.location.href = `https://checkout.stripe.com/pay/${data.sessionId}`;
+          if (data.checkout_url) {
+              window.location.href = data.checkout_url;
           } else {
               alert("Error: " + data.error);
           }

--- a/learning/templates/learning/worksheet_lab.html
+++ b/learning/templates/learning/worksheet_lab.html
@@ -344,8 +344,8 @@
         });
 
         const data = await response.json();
-        if (data.sessionId) {
-          window.location.href = `https://checkout.stripe.com/pay/${data.sessionId}`;
+        if (data.checkout_url) {
+          window.location.href = data.checkout_url;
         } else {
           alert("Error: " + data.error);
         }

--- a/learning/views.py
+++ b/learning/views.py
@@ -1454,7 +1454,7 @@ def create_checkout_session(request):
                 }
             },
         )
-        return JsonResponse({"sessionId": session.id})
+        return JsonResponse({"checkout_url": session.url})
 
     except stripe.error.StripeError as e:
         return JsonResponse({"error": str(e)}, status=400)

--- a/learning/webhooks.py
+++ b/learning/webhooks.py
@@ -7,6 +7,7 @@ from django.utils.timezone import now
 from datetime import timedelta
 from django.conf import settings
 
+stripe.api_key = settings.STRIPE_SECRET_KEY  # Ensure API key is set for webhook calls
 logger = logging.getLogger(__name__)
 
 @csrf_exempt


### PR DESCRIPTION
## Summary
- Redirect teachers to Stripe using checkout session URL
- Use returned checkout URL in Worksheet Lab upgrade flow
- Configure Stripe API key in webhook for membership updates

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b9561b4ad88325bc131ca47aa2b7d7