### PR TITLE
Integrate toast notifications using Django messages

### DIFF
--- a/blog/templates/blog/blog_detail.html
+++ b/blog/templates/blog/blog_detail.html
@@ -118,5 +118,6 @@
     <!-- Return to Blog Button -->
     <a href="{% url 'blog_list' %}" class="return-btn"><i class="fas fa-arrow-left"></i> Return to Blog</a>
 
+{% include 'messages.html' %}
 </body>
 </html>

--- a/blog/templates/blog/blog_list.html
+++ b/blog/templates/blog/blog_list.html
@@ -124,5 +124,6 @@
 <a href="https://www.pavonify.com" class="back-btn"><i class="fas fa-home"></i> Back to Homepage</a>
 
 
+{% include 'messages.html' %}
 </body>
 </html>

--- a/blog/views.py
+++ b/blog/views.py
@@ -1,9 +1,12 @@
 from django.shortcuts import render, get_object_or_404
+from django.contrib import messages
 from .models import BlogPost
 
 def blog_list(request):
     """Show all blog posts."""
     posts = BlogPost.objects.all()
+    if not posts:
+        messages.info(request, "No blog posts available.")
     return render(request, "blog/blog_list.html", {"posts": posts})
 
 def blog_detail(request, slug):

--- a/game/views.py
+++ b/game/views.py
@@ -13,6 +13,7 @@ from django.views.decorators.csrf import csrf_exempt
 import json
 
 from django.contrib.auth import get_user_model
+from django.contrib import messages
 
 User = get_user_model()
 
@@ -48,8 +49,8 @@ def host_game(request):
         # Initialize country ownership: set every country to neutral for this game.
         for country in Country.objects.all():
             GameCountryOwnership.objects.create(live_game=game, country=country)
-        
-        # Redirect to the game lobby page (adjust URL name as needed)
+
+        messages.success(request, "Game created successfully!")
         return redirect("game_lobby", game_id=game.id)
 
     # On GET, show available vocabulary lists and teacher's classes.

--- a/learning/templates/learning/404.html
+++ b/learning/templates/learning/404.html
@@ -69,5 +69,6 @@
         }
     </script>
 
+{% include 'messages.html' %}
 </body>
 </html>

--- a/learning/templates/learning/access_denied.html
+++ b/learning/templates/learning/access_denied.html
@@ -10,5 +10,6 @@
     <h1>Access Denied</h1>
     <p>You do not have permission to access this assignment.</p>
     <a href="{% url 'student_dashboard' %}">Return to Dashboard</a>
+{% include 'messages.html' %}
 </body>
 </html>

--- a/learning/templates/learning/add_students.html
+++ b/learning/templates/learning/add_students.html
@@ -126,5 +126,6 @@
     </form>
     <a href="{% url 'edit_class' class_instance.id %}" class="back-link">Back to Class</a>
   </div>
+{% include 'messages.html' %}
 </body>
 </html>

--- a/learning/templates/learning/add_vocabulary_list.html
+++ b/learning/templates/learning/add_vocabulary_list.html
@@ -112,5 +112,6 @@
       <button type="submit">Create Vocabulary List</button>
     </form>
   </div>
+{% include 'messages.html' %}
 </body>
 </html>

--- a/learning/templates/learning/assignment_analytics.html
+++ b/learning/templates/learning/assignment_analytics.html
@@ -307,5 +307,6 @@
     enhanceDifficultWordCloud();
     enhanceEasyWordCloud();
   </script>
+{% include 'messages.html' %}
 </body>
 </html>

--- a/learning/templates/learning/assignment_modes/destroy_the_wall_assignment.html
+++ b/learning/templates/learning/assignment_modes/destroy_the_wall_assignment.html
@@ -135,5 +135,6 @@
             wall.appendChild(brick);
         });
     </script>
+{% include 'messages.html' %}
 </body>
 </html>

--- a/learning/templates/learning/assignment_modes/flashcard_mode_assignment.html
+++ b/learning/templates/learning/assignment_modes/flashcard_mode_assignment.html
@@ -137,5 +137,6 @@ body {
         // Initialize the first card
         updateCard(currentIndex);
     </script>
+{% include 'messages.html' %}
 </body>
 </html>

--- a/learning/templates/learning/assignment_modes/gap_fill_mode_assignment.html
+++ b/learning/templates/learning/assignment_modes/gap_fill_mode_assignment.html
@@ -289,5 +289,6 @@
         });
     </script>
 
+{% include 'messages.html' %}
 </body>
 </html>

--- a/learning/templates/learning/assignment_modes/listening_dictation_assignment.html
+++ b/learning/templates/learning/assignment_modes/listening_dictation_assignment.html
@@ -279,5 +279,6 @@
     createAccentKeyboard();
   </script>
 
+{% include 'messages.html' %}
 </body>
 </html>

--- a/learning/templates/learning/assignment_modes/listening_translation_assignment.html
+++ b/learning/templates/learning/assignment_modes/listening_translation_assignment.html
@@ -271,5 +271,6 @@
     createAccentKeyboard();
   </script>
 
+{% include 'messages.html' %}
 </body>
 </html>

--- a/learning/templates/learning/assignment_modes/match_up_mode_assignment.html
+++ b/learning/templates/learning/assignment_modes/match_up_mode_assignment.html
@@ -289,5 +289,6 @@
       }
     });
   </script>
+{% include 'messages.html' %}
 </body>
 </html>

--- a/learning/templates/learning/assignment_modes/unscramble_the_word_assignment.html
+++ b/learning/templates/learning/assignment_modes/unscramble_the_word_assignment.html
@@ -175,5 +175,6 @@
 
     displayWord();
   </script>
+{% include 'messages.html' %}
 </body>
 </html>

--- a/learning/templates/learning/assignment_page.html
+++ b/learning/templates/learning/assignment_page.html
@@ -286,5 +286,6 @@
         });
     </script>
 
+{% include 'messages.html' %}
 </body>
 </html>

--- a/learning/templates/learning/base.html
+++ b/learning/templates/learning/base.html
@@ -23,5 +23,6 @@
         <!-- Page-specific content will go here -->
         {% endblock %}
     </div>
+{% include 'messages.html' %}
 </body>
 </html>

--- a/learning/templates/learning/class_leaderboard.html
+++ b/learning/templates/learning/class_leaderboard.html
@@ -195,5 +195,6 @@
     // Start the timer with the default interval when the page loads.
     startRefreshTimer();
   </script>
+{% include 'messages.html' %}
 </body>
 </html>

--- a/learning/templates/learning/create_assignment.html
+++ b/learning/templates/learning/create_assignment.html
@@ -235,5 +235,6 @@
     <button type="submit">Create Assignment</button>       <button onclick="history.back();" class="back-btn">Back</button>
 
   </form>
+{% include 'messages.html' %}
 </body>
 </html>

--- a/learning/templates/learning/create_class.html
+++ b/learning/templates/learning/create_class.html
@@ -133,5 +133,6 @@
       <button type="submit">Create Class</button>
     </form>
   </div>
+{% include 'messages.html' %}
 </body>
 </html>

--- a/learning/templates/learning/delete_vocabulary_list.html
+++ b/learning/templates/learning/delete_vocabulary_list.html
@@ -89,5 +89,6 @@
     </form>
     <a href="{% url 'vocabulary_list' %}" class="cancel-link">Cancel</a>
   </div>
+{% include 'messages.html' %}
 </body>
 </html>

--- a/learning/templates/learning/destroy_the_wall.html
+++ b/learning/templates/learning/destroy_the_wall.html
@@ -269,5 +269,6 @@
       return cookieValue;
     }
   </script>
+{% include 'messages.html' %}
 </body>
 </html>

--- a/learning/templates/learning/edit_class.html
+++ b/learning/templates/learning/edit_class.html
@@ -210,5 +210,6 @@
     <!-- Back to Dashboard Link at the Bottom -->
     <a href="{% url 'teacher_dashboard' %}" class="back-link">Back to Dashboard</a>
   </div>
+{% include 'messages.html' %}
 </body>
 </html>

--- a/learning/templates/learning/edit_vocabulary_list_details.html
+++ b/learning/templates/learning/edit_vocabulary_list_details.html
@@ -134,5 +134,6 @@
       </a>
     </div>
   </div>
+{% include 'messages.html' %}
 </body>
 </html>

--- a/learning/templates/learning/edit_vocabulary_words.html
+++ b/learning/templates/learning/edit_vocabulary_words.html
@@ -158,5 +158,6 @@
       <a href="{% url 'teacher_dashboard' %}" class="btn">Back to Dashboard</a>
     </div>
   </div>
+{% include 'messages.html' %}
 </body>
 </html>

--- a/learning/templates/learning/flashcard_mode.html
+++ b/learning/templates/learning/flashcard_mode.html
@@ -197,5 +197,6 @@
       updateCard();
     </script>
   </div>
+{% include 'messages.html' %}
 </body>
 </html>

--- a/learning/templates/learning/gap_fill_mode.html
+++ b/learning/templates/learning/gap_fill_mode.html
@@ -283,5 +283,6 @@
     // Initialize the first word
     displayWord();
   </script>
+{% include 'messages.html' %}
 </body>
 </html>

--- a/learning/templates/learning/grammar_lab.html
+++ b/learning/templates/learning/grammar_lab.html
@@ -195,6 +195,7 @@ body {
     </div>
   </div>
 </div>
+{% include 'messages.html' %}
 </body>
 
 <script>

--- a/learning/templates/learning/grammar_ladder_detail.html
+++ b/learning/templates/learning/grammar_ladder_detail.html
@@ -144,5 +144,6 @@
   }
 </script>
 
+{% include 'messages.html' %}
 </body>
 </html>

--- a/learning/templates/learning/landing_page.html
+++ b/learning/templates/learning/landing_page.html
@@ -695,5 +695,6 @@
     <p>&copy; 2025 Pavonify. All rights reserved.</p>
     <p><a href="{% static 'Privacy Policy for Pavonify.pdf' %}" target="_blank">Privacy Policy</a></p>
   </footer>
+{% include 'messages.html' %}
 </body>
 </html>

--- a/learning/templates/learning/lead_teacher_dashboard.html
+++ b/learning/templates/learning/lead_teacher_dashboard.html
@@ -30,5 +30,6 @@
         <li>{{ vocab_list.name }}</li>
         {% endfor %}
     </ul>
+{% include 'messages.html' %}
 </body>
 </html>

--- a/learning/templates/learning/lead_teacher_login.html
+++ b/learning/templates/learning/lead_teacher_login.html
@@ -15,5 +15,6 @@
         <input type="password" id="password" name="password" required><br><br>
         <button type="submit">Login</button>
     </form>
+{% include 'messages.html' %}
 </body>
 </html>

--- a/learning/templates/learning/leaderboard.html
+++ b/learning/templates/learning/leaderboard.html
@@ -23,5 +23,6 @@
             {% endfor %}
         </tbody>
     </table>
+{% include 'messages.html' %}
 </body>
 </html>

--- a/learning/templates/learning/listening_dictation.html
+++ b/learning/templates/learning/listening_dictation.html
@@ -296,5 +296,6 @@ function updateServerPoints(points) {
     document.getElementById("submit-answer").addEventListener("click", checkAnswer);
     createAccentKeyboard();
   </script>
+{% include 'messages.html' %}
 </body>
 </html>

--- a/learning/templates/learning/listening_translation.html
+++ b/learning/templates/learning/listening_translation.html
@@ -256,5 +256,6 @@
     document.getElementById("play-word").addEventListener("click", speakWord);
     document.getElementById("submit-answer").addEventListener("click", checkAnswer);
   </script>
+{% include 'messages.html' %}
 </body>
 </html>

--- a/learning/templates/learning/match_up_mode.html
+++ b/learning/templates/learning/match_up_mode.html
@@ -268,5 +268,6 @@
       return cookieValue;
     }
   </script>
+{% include 'messages.html' %}
 </body>
 </html>

--- a/learning/templates/learning/my_words.html
+++ b/learning/templates/learning/my_words.html
@@ -68,6 +68,7 @@
     document.getElementById('search').addEventListener('input', fetchWords);
     document.getElementById('sort').addEventListener('change', fetchWords);
     </script>
+{% include 'messages.html' %}
 </body>
 </html>
 

--- a/learning/templates/learning/payment_success.html
+++ b/learning/templates/learning/payment_success.html
@@ -39,5 +39,6 @@
         <p>Your subscription has been activated.</p>
         <a href="{% url 'teacher_dashboard' %}" class="btn">Go to Dashboard</a>
     </div>
+{% include 'messages.html' %}
 </body>
 </html>

--- a/learning/templates/learning/practice_session.html
+++ b/learning/templates/learning/practice_session.html
@@ -307,5 +307,6 @@
         return cookieValue;
     }
 </script>
+{% include 'messages.html' %}
 </body>
 </html>

--- a/learning/templates/learning/progress_dashboard.html
+++ b/learning/templates/learning/progress_dashboard.html
@@ -53,5 +53,6 @@
       {% endfor %}
     </div>
   </div>
+{% include 'messages.html' %}
 </body>
 </html>

--- a/learning/templates/learning/reading_lab.html
+++ b/learning/templates/learning/reading_lab.html
@@ -287,5 +287,6 @@
       document.querySelectorAll(".word-selection-box input[type='checkbox']").forEach(cb => cb.checked = state);
     }
   </script>
+{% include 'messages.html' %}
 </body>
 </html>

--- a/learning/templates/learning/reading_lab_display.html
+++ b/learning/templates/learning/reading_lab_display.html
@@ -195,5 +195,6 @@
             highlightDoubleAsterisks(document.querySelector(".target-text-content"));
         });
     </script>
+{% include 'messages.html' %}
 </body>
 </html>

--- a/learning/templates/learning/register_success.html
+++ b/learning/templates/learning/register_success.html
@@ -9,5 +9,6 @@
     <h1>🎉 Registration Complete!</h1>
     <p>Thank you for signing up for Premium. You can now access all features.</p>
     <a href="{% url 'teacher_dashboard' %}">Go to Dashboard</a>
+{% include 'messages.html' %}
 </body>
 </html>

--- a/learning/templates/learning/register_teacher.html
+++ b/learning/templates/learning/register_teacher.html
@@ -222,5 +222,6 @@
       </form>
     </div>
   </div>
+{% include 'messages.html' %}
 </body>
 </html>

--- a/learning/templates/learning/school_signup.html
+++ b/learning/templates/learning/school_signup.html
@@ -8,5 +8,6 @@
 <body>
     <h1>School Signup</h1>
     <p>This page will eventually allow schools to register and purchase licenses.</p>
+{% include 'messages.html' %}
 </body>
 </html>

--- a/learning/templates/learning/student_dashboard.html
+++ b/learning/templates/learning/student_dashboard.html
@@ -557,5 +557,6 @@
 
     // (Existing script for pagination in leaderboards remains unchanged)
   </script>
+{% include 'messages.html' %}
 </body>
 </html>

--- a/learning/templates/learning/student_login.html
+++ b/learning/templates/learning/student_login.html
@@ -227,5 +227,6 @@
       </form>
     </div>
   </div>
+{% include 'messages.html' %}
 </body>
 </html>

--- a/learning/templates/learning/teacher_dashboard.html
+++ b/learning/templates/learning/teacher_dashboard.html
@@ -973,5 +973,6 @@ a.btn:hover, button.btn:hover {
   }
 </script>
 
+{% include 'messages.html' %}
 </body>
 </html>

--- a/learning/templates/learning/unscramble_the_word.html
+++ b/learning/templates/learning/unscramble_the_word.html
@@ -252,5 +252,6 @@
     // Initialize the first word
     displayWord();
   </script>
+{% include 'messages.html' %}
 </body>
 </html>

--- a/learning/templates/learning/view_assignments.html
+++ b/learning/templates/learning/view_assignments.html
@@ -32,5 +32,6 @@
         </tbody>
     </table>
     <a href="{% url 'create_assignment' %}">Create New Assignment</a>
+{% include 'messages.html' %}
 </body>
 </html>

--- a/learning/templates/learning/view_attached_vocab.html
+++ b/learning/templates/learning/view_attached_vocab.html
@@ -102,5 +102,6 @@
     </ul>
     <a href="{% url 'teacher_dashboard' %}" class="back-link">Back to Dashboard</a>
   </div>
+{% include 'messages.html' %}
 </body>
 </html>

--- a/learning/templates/learning/view_vocabulary.html
+++ b/learning/templates/learning/view_vocabulary.html
@@ -17,5 +17,6 @@
         {% endfor %}
     </ul>
     <a href="{% url 'student_dashboard' %}">Back to Dashboard</a>
+{% include 'messages.html' %}
 </body>
 </html>

--- a/learning/templates/learning/view_vocabulary_words.html
+++ b/learning/templates/learning/view_vocabulary_words.html
@@ -149,5 +149,6 @@
       <a href="{% url 'teacher_dashboard' %}" class="back-link">Back to Dashboard</a>
     </div>
   </div>
+{% include 'messages.html' %}
 </body>
 </html>

--- a/learning/templates/learning/worksheet_lab.html
+++ b/learning/templates/learning/worksheet_lab.html
@@ -1141,5 +1141,6 @@ window.onload = function() {
 };
 
     </script>
+{% include 'messages.html' %}
 </body>
 </html>

--- a/learning/templates/registration/login.html
+++ b/learning/templates/registration/login.html
@@ -213,5 +213,6 @@
       <button type="button" class="back-button" onclick="window.history.back();">Back</button>
     </div>
   </div>
+{% include 'messages.html' %}
 </body>
 </html>

--- a/templates/base.html
+++ b/templates/base.html
@@ -23,5 +23,6 @@
         <!-- Page-specific content will go here -->
         {% endblock %}
     </div>
+{% include 'messages.html' %}
 </body>
 </html>

--- a/templates/learning/my_words.html
+++ b/templates/learning/my_words.html
@@ -67,5 +67,6 @@
         <p>No words to display.</p>
         {% endfor %}
     </div>
+{% include 'messages.html' %}
 </body>
 </html>

--- a/templates/messages.html
+++ b/templates/messages.html
@@ -1,0 +1,12 @@
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.css">
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.js"></script>
+<script>
+  $(function() {
+    {% if messages %}
+      {% for message in messages %}
+        toastr["{{ message.tags|default:'info' }}"]("{{ message|escapejs }}");
+      {% endfor %}
+    {% endif %}
+  });
+</script>


### PR DESCRIPTION
## Summary
- Add reusable `messages.html` snippet powered by Toastr and include it across templates
- Surface server-side success/info notifications in blog and game views via Django messages

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b95f58fb9083259a981db0b6572a21