### PR TITLE
Add difficulty percentage to assignment analytics

### DIFF
--- a/learning/templates/learning/assignment_analytics.html
+++ b/learning/templates/learning/assignment_analytics.html
@@ -197,6 +197,7 @@
     <!-- Word Summary Tab -->
     <div class="tab-content" id="word-summary">
       <h2>Word Summary</h2>
+      <p class="legend"><em>Difficulty meter shows percentage of attempts that were incorrect.</em></p>
       <table>
         <thead>
           <tr>
@@ -210,7 +211,7 @@
           <tr>
             <td>{{ word.word }}</td>
             <td>
-              <div class="difficulty-bar" style="width: {{ word.wrong_attempts|floatformat:0 }}%;"></div>
+              <div class="difficulty-bar" title="{{ word.difficulty_percentage|floatformat:1 }}% of attempts incorrect" style="width: {{ word.difficulty_percentage|floatformat:0 }}%;"></div>
             </td>
             <td>{{ word.students_difficulty }} students found this word difficult</td>
           </tr>

--- a/learning/views.py
+++ b/learning/views.py
@@ -2297,16 +2297,29 @@ def assignment_analytics(request, assignment_id):
         word_id = att.vocabulary_word.id
         if word_id not in word_summary_dict:
             # Use the target word (translation) instead of the source word
-            word_summary_dict[word_id] = {"word": att.vocabulary_word.translation, "wrong_attempts": 0, "students": set()}
+            word_summary_dict[word_id] = {
+                "word": att.vocabulary_word.translation,
+                "wrong_attempts": 0,
+                "total_attempts": 0,
+                "students": set(),
+            }
+
+        # Track total attempts for percentage calculation
+        word_summary_dict[word_id]["total_attempts"] += 1
+
         if not att.is_correct:
             word_summary_dict[word_id]["wrong_attempts"] += 1
             word_summary_dict[word_id]["students"].add(att.student.id)
+
     word_summary_list = []
     for w in word_summary_dict.values():
+        total = w["total_attempts"]
+        percentage = (w["wrong_attempts"] / total) * 100 if total else 0
         word_summary_list.append({
             "word": w["word"],
             "wrong_attempts": w["wrong_attempts"],
             "students_difficulty": len(w["students"]),
+            "difficulty_percentage": percentage,
         })
     
     # --- Feedback Aggregation ---


### PR DESCRIPTION
## Summary
- compute per-word incorrect-attempt percentage in assignment analytics
- display difficulty bars using this percentage and include tooltip
- add legend clarifying difficulty metric

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b960e7f9e48325a2f694093e4e969e