### PR TITLE
Reset class leaderboard points weekly and monthly

### DIFF
--- a/learning/models.py
+++ b/learning/models.py
@@ -131,18 +131,23 @@ class Student(models.Model):
 
     def reset_periodic_points(self):
         today = now().date()
+        updated = False
         if (
             self.weekly_points_last_reset.isocalendar()[1] != today.isocalendar()[1]
             or self.weekly_points_last_reset.year != today.year
         ):
             self.weekly_points = 0
             self.weekly_points_last_reset = today
+            updated = True
         if (
             self.monthly_points_last_reset.month != today.month
             or self.monthly_points_last_reset.year != today.year
         ):
             self.monthly_points = 0
             self.monthly_points_last_reset = today
+            updated = True
+        if updated:
+            self.save()
 
     def add_points(self, amount):
         self.reset_periodic_points()

--- a/learning/views.py
+++ b/learning/views.py
@@ -494,6 +494,8 @@ def student_dashboard(request):
     classes = student.classes.all()
 
     for class_instance in classes:
+        for class_student in class_instance.students.all():
+            class_student.reset_periodic_points()
         live_assignments = Assignment.objects.filter(class_assigned=class_instance, deadline__gte=now())
         expired_assignments = Assignment.objects.filter(class_assigned=class_instance, deadline__lt=now())
 
@@ -844,7 +846,10 @@ def class_leaderboard(request, class_id):
     if category not in {"total_points", "weekly_points", "monthly_points"}:
         category = "total_points"
 
-    students = class_instance.students.all().order_by(f"-{category}")
+    students_qs = class_instance.students.all()
+    for student in students_qs:
+        student.reset_periodic_points()
+    students = students_qs.order_by(f"-{category}")
     column_labels = {
         "total_points": "Total Points",
         "weekly_points": "Weekly Points",
@@ -870,7 +875,10 @@ def refresh_leaderboard(request, class_id):
     if category not in {"total_points", "weekly_points", "monthly_points"}:
         category = "total_points"
 
-    students = class_instance.students.all().order_by(f"-{category}")
+    students_qs = class_instance.students.all()
+    for student in students_qs:
+        student.reset_periodic_points()
+    students = students_qs.order_by(f"-{category}")
     column_labels = {
         "total_points": "Total Points",
         "weekly_points": "Weekly Points",


### PR DESCRIPTION
## Summary
- automatically persist weekly/monthly point resets in `Student.reset_periodic_points`
- ensure student dashboard refreshes leaderboard points for all classmates
- reset points for all class members in teacher class leaderboard views

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68c26c92ce28832591fe3501c7206f8c