### PR TITLE
Use database-backed sessions

### DIFF
--- a/lang_platform/settings.py
+++ b/lang_platform/settings.py
@@ -131,8 +131,8 @@ LOGIN_URL = '/login/'
 LOGIN_REDIRECT_URL = '/teacher-dashboard/'
 
 # Session Settings
-SESSION_ENGINE = "django.contrib.sessions.backends.cache"
-SESSION_CACHE_ALIAS = "default"
+# Use database-backed sessions for reliability across multiple workers
+SESSION_ENGINE = "django.contrib.sessions.backends.db"
 
 # Enforce HTTPS
 SECURE_SSL_REDIRECT = False  # ✅ Only redirect if NOT in DEBUG mode


### PR DESCRIPTION
## Summary
- ensure sessions persist by using database-backed session engine

## Testing
- `python manage.py test`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3a92db83883258658dbe53f9d65e4