### PR TITLE
Improve practice session flow

### DIFF
--- a/learning/templates/learning/practice_session.html
+++ b/learning/templates/learning/practice_session.html
@@ -60,29 +60,34 @@
             top: 10px;
             left: 10px;
         }
-        .shimmer {
-            position: relative;
-            overflow: hidden;
+        .btn {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            padding: 10px 15px;
+            margin: 5px;
+            background-color: #1A73E8;
+            color: #fff;
+            border: none;
+            border-radius: 6px;
+            text-transform: uppercase;
+            font-weight: 600;
+            cursor: pointer;
+            transition: background-color 0.3s ease, transform 0.2s ease;
+            text-decoration: none;
         }
-        .shimmer::after {
-            content: '';
-            position: absolute;
-            top: 0;
-            left: -100%;
-            width: 100%;
-            height: 100%;
-            background: linear-gradient(90deg, rgba(255,255,255,0) 0%, rgba(255,255,255,0.4) 50%, rgba(255,255,255,0) 100%);
-            animation: shimmer 1.5s infinite;
+        .btn:hover {
+            background-color: #F2A03D;
+            transform: translateY(-2px);
         }
-        @keyframes shimmer {
-            0% { left: -100%; }
-            100% { left: 100%; }
+        .btn:active {
+            transform: translateY(0);
         }
     </style>
 </head>
 <body>
 <div class="pane">
-    <button class="back-button btn btn-primary" onclick="window.history.back()">Back</button>
+    <button class="back-button btn" onclick="window.history.back()">Back</button>
     <h1>Practice Session - {{ vocab_list.name }}</h1>
     <p><strong>Session Points:</strong> <span id="session-points">0</span></p>
     <div id="activity-container"></div>
@@ -123,9 +128,6 @@
             case 'flashcard':
                 renderFlashcard(activity);
                 break;
-            case 'shimmer':
-                renderShimmer(activity);
-                break;
             case 'typing':
                 renderTyping(activity);
                 break;
@@ -148,10 +150,10 @@
         container.innerHTML = `
             <div class="show-word">
                 <p>${activity.prompt}</p>
-                <button id="reveal-word" class="btn btn-primary">Show Word</button>
+                <button id="reveal-word" class="btn">Show Word</button>
                 <div id="revealed-word" style="display:none; margin-top:10px;">${activity.answer}</div>
                 <div style="margin-top:10px;">
-                    <button id="show-word-next" class="btn btn-primary" style="display:none;">Next</button>
+                    <button id="show-word-next" class="btn" style="display:none;">Next</button>
                 </div>
             </div>
         `;
@@ -171,10 +173,10 @@
         container.innerHTML = `
             <div class="flashcard">
                 <p>${activity.prompt}</p>
-                <button id="show-answer" class="btn btn-primary">Show Answer</button>
+                <button id="show-answer" class="btn">Show Answer</button>
                 <div id="answer" style="display:none; margin-top:10px;">${activity.answer}</div>
                 <div style="margin-top:10px;">
-                    <button id="flashcard-done" class="btn btn-primary" style="display:none;">I got it!</button>
+                    <button id="flashcard-done" class="btn" style="display:none;">I got it!</button>
                 </div>
             </div>
         `;
@@ -189,28 +191,13 @@
         });
     }
 
-    function renderShimmer(activity) {
-        const container = document.getElementById('activity-container');
-        container.innerHTML = `
-            <div class="shimmer-card">
-                <p class="shimmer">${activity.prompt}</p>
-                <p class="shimmer">${activity.answer}</p>
-                <button id="shimmer-next" class="btn btn-primary">Next</button>
-            </div>
-        `;
-
-        document.getElementById('shimmer-next').addEventListener('click', () => {
-            submitResponse(activity.word_id, true);
-        });
-    }
-
     function renderTyping(activity) {
         const container = document.getElementById('activity-container');
         container.innerHTML = `
             <div class="typing">
                 <p>${activity.prompt}</p>
                 <input type="text" id="typing-input" />
-                <button id="typing-submit" class="btn btn-primary">Submit</button>
+                <button id="typing-submit" class="btn">Submit</button>
             </div>
         `;
         document.getElementById('typing-submit').addEventListener('click', () => {
@@ -227,7 +214,7 @@
                 <p>${activity.translation}</p>
                 <p>${activity.prompt}</p>
                 <input type="text" id="fill-gaps-input" />
-                <button id="fill-gaps-submit" class="btn btn-primary">Submit</button>
+                <button id="fill-gaps-submit" class="btn">Submit</button>
             </div>
         `;
         document.getElementById('fill-gaps-submit').addEventListener('click', () => {
@@ -243,7 +230,7 @@
             <div class="multiple-choice">
                 <p>${activity.prompt}</p>
                 <div id="match-options">
-                    ${activity.options.map(opt => `<button class="match-option btn btn-primary">${opt}</button>`).join('')}
+                    ${activity.options.map(opt => `<button class="match-option btn">${opt}</button>`).join('')}
                 </div>
             </div>
         `;
@@ -261,8 +248,8 @@
         container.innerHTML = `
             <div class="true-false">
                 <p>${activity.prompt} - ${activity.shown_translation}</p>
-                <button id="true-btn" class="btn btn-primary">True</button>
-                <button id="false-btn" class="btn btn-primary">False</button>
+                <button id="true-btn" class="btn">True</button>
+                <button id="false-btn" class="btn">False</button>
             </div>
         `;
         document.getElementById('true-btn').addEventListener('click', () => {

--- a/learning/views.py
+++ b/learning/views.py
@@ -612,10 +612,10 @@ def practice_session(request, vocab_list_id):
 
     queue_key = f"practice_queue_{vocab_list_id}"
     queue = request.session.get(queue_key, [])
-    activities = ["show_word", "flashcard", "shimmer", "typing", "fill_gaps", "multiple_choice", "true_false"]
+    activities = ["show_word", "flashcard", "typing", "fill_gaps", "multiple_choice", "true_false"]
 
     def _init_queue():
-        words = get_due_words(student, vocab_list, limit=20)
+        words = get_due_words(student, vocab_list, limit=3)
         return [{"id": w.id, "step": 0} for w in words]
 
     if request.headers.get("x-requested-with") == "XMLHttpRequest" or request.GET.get("next"):
@@ -624,22 +624,19 @@ def practice_session(request, vocab_list_id):
         if not queue:
             return JsonResponse({"completed": True})
 
-        item = queue[0]
+        item = queue.pop(0)
         word = VocabularyWord.objects.get(id=item["id"])
         activity = activities[item["step"]]
 
         if item["step"] + 1 < len(activities):
-            queue[0]["step"] += 1
-        else:
-            queue.pop(0)
+            item["step"] += 1
+            queue.append(item)
         request.session[queue_key] = queue
 
         if activity == "show_word":
             payload = {"type": "show_word", "word_id": word.id, "prompt": word.translation, "answer": word.word}
         elif activity == "flashcard":
             payload = {"type": "flashcard", "word_id": word.id, "prompt": word.word, "answer": word.translation}
-        elif activity == "shimmer":
-            payload = {"type": "shimmer", "word_id": word.id, "prompt": word.word, "answer": word.translation}
         elif activity == "typing":
             payload = {"type": "typing", "word_id": word.id, "prompt": word.word, "answer": word.translation}
         elif activity == "fill_gaps":


### PR DESCRIPTION
## Summary
- Style practice session buttons like dashboard buttons
- Remove unused shimmer activity
- Rotate through three vocabulary words during practice sessions

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68c3b4b58ea08325bdd8f5ec91f8f6e6