### PR TITLE
Fix student dashboard leaderboard ordering

### DIFF
--- a/learning/templates/learning/student_dashboard.html
+++ b/learning/templates/learning/student_dashboard.html
@@ -332,13 +332,13 @@
                   <h5 style="font-size: 16px; font-weight: bold; color: #ff8c00; margin-bottom: 5px; text-align: center;">{{ leaderboard.title }} {{ leaderboard.icon }}</h5>
                   <hr style="height: 2px; background-color: #ddd; border: none; margin-bottom: 10px;">
                   <ol class="leaderboard-list" id="leaderboard-{{ class_instance.id }}-{{ leaderboard.category }}" style="list-style: none; padding: 0;">
-                    {% for student in class_instance.students.all|dictsortreversed:leaderboard.category %}
+                    {% for student in class_instance.leaderboards|dictlookup:leaderboard.category %}
                       <li class="leaderboard-item" style="display: flex; justify-content: space-between; align-items: center; padding: 5px 0; font-size: 14px; font-weight: bold; color: #333;">
                         <span class="medal" style="font-size: 16px; margin-right: 5px;">
                           {% if forloop.counter == 1 %}🥇{% elif forloop.counter == 2 %}🥈{% elif forloop.counter == 3 %}🥉{% endif %}
                         </span>
                         <span class="student-name" style="flex-grow: 1;">{{ student.first_name }} {{ student.last_name }}</span>
-                        <span class="student-score" style="font-weight: bold; color: #28a745;">{{ student.total_points }} pts</span>
+                        <span class="student-score" style="font-weight: bold; color: #28a745;">{{ student|get_attr:leaderboard.category }} pts</span>
                       </li>
                     {% empty %}
                       <li class="no-students" style="text-align: center; font-size: 14px; color: #777;">No students available for this leaderboard.</li>

--- a/learning/templatetags/custom_filters.py
+++ b/learning/templatetags/custom_filters.py
@@ -6,3 +6,9 @@ register = template.Library()
 def dictlookup(dictionary, key):
     """Retrieve value from dictionary by key in Django templates."""
     return dictionary.get(key, 0)
+
+
+@register.filter
+def get_attr(obj, attr_name):
+    """Get attribute of an object by name in templates."""
+    return getattr(obj, attr_name, 0)

--- a/learning/views.py
+++ b/learning/views.py
@@ -514,6 +514,11 @@ def student_dashboard(request):
 
         class_instance.live_assignments = live_assignments
         class_instance.expired_assignments = expired_assignments
+        class_instance.leaderboards = {
+            "total_points": class_instance.students.order_by("-total_points"),
+            "monthly_points": class_instance.students.order_by("-monthly_points"),
+            "weekly_points": class_instance.students.order_by("-weekly_points"),
+        }
 
     vocab_lists = VocabularyList.objects.filter(classes__in=classes).distinct()
     leaderboard_categories = [


### PR DESCRIPTION
## Summary
- order student leaderboards by total, monthly, and weekly points
- add template filter for dynamic attribute lookup
- show correct point type in student leaderboard sections

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68c3cbd7019483259fe0430af97c9895