### PR TITLE
Add match-up activity to student practice

### DIFF
--- a/learning/templates/learning/practice_session.html
+++ b/learning/templates/learning/practice_session.html
@@ -117,6 +117,33 @@
             border-radius: 4px;
             transition: width 0.3s ease;
         }
+        .match-up-container {
+            display: flex;
+            justify-content: space-around;
+            margin-top: 20px;
+        }
+        .match-column {
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+        }
+        .match-tile, .match-target {
+            padding: 10px;
+            background: #fff;
+            color: #000;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+            min-width: 120px;
+            min-height: 40px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+        .match-target.correct {
+            background: #4caf50;
+            color: #fff;
+            font-weight: bold;
+        }
     </style>
 </head>
 <body>
@@ -188,6 +215,9 @@
                 break;
             case 'true_false':
                 renderTrueFalse(activity);
+                break;
+            case 'match_up':
+                renderMatchUp(activity);
                 break;
             default:
                 container.innerHTML = '<p>Unknown activity type.</p>';
@@ -311,6 +341,57 @@
         });
     }
 
+    function renderMatchUp(activity) {
+        const container = document.getElementById('activity-container');
+        container.innerHTML = `
+            <div class="match-up-container">
+                <div class="match-column" id="match-l1"></div>
+                <div class="match-column" id="match-l2"></div>
+            </div>
+        `;
+        const left = document.getElementById('match-l1');
+        const right = document.getElementById('match-l2');
+        activity.words.forEach(w => {
+            const tile = document.createElement('div');
+            tile.className = 'match-tile';
+            tile.draggable = true;
+            tile.dataset.id = w.id;
+            tile.textContent = w.word;
+            left.appendChild(tile);
+
+            const target = document.createElement('div');
+            target.className = 'match-target';
+            target.dataset.id = w.id;
+            target.textContent = w.translation;
+            right.appendChild(target);
+        });
+
+        document.querySelectorAll('.match-tile').forEach(tile => {
+            tile.addEventListener('dragstart', e => {
+                e.dataTransfer.setData('text', e.target.dataset.id);
+                e.dataTransfer.setData('text-word', e.target.textContent);
+            });
+        });
+
+        document.querySelectorAll('.match-target').forEach(target => {
+            target.addEventListener('dragover', e => e.preventDefault());
+            target.addEventListener('drop', e => {
+                const id = e.dataTransfer.getData('text');
+                const word = e.dataTransfer.getData('text-word');
+                if (id === e.target.dataset.id) {
+                    e.target.classList.add('correct');
+                    e.target.textContent = `${word} = ${e.target.textContent}`;
+                    const tile = document.querySelector(`.match-tile[data-id='${id}']`);
+                    if (tile) tile.remove();
+                    submitResponse(parseInt(id), true, null, null, true, false);
+                    if (document.querySelectorAll('.match-tile').length === 0) {
+                        setTimeout(() => fetchActivity(), 500);
+                    }
+                }
+            });
+        });
+    }
+
     function updateStreak(correct, count=true) {
         if (count) {
             if (correct) {
@@ -358,7 +439,7 @@
         fb.textContent = correct ? 'Correct!' : `Incorrect. Correct answer: ${correctAnswer}`;
     }
 
-    async function submitResponse(wordId, correct, answer=null, correctAnswer=null, count=true) {
+    async function submitResponse(wordId, correct, answer=null, correctAnswer=null, count=true, next=true) {
         try {
             await fetch("{% url 'update_progress' %}", {
                 method: 'POST',
@@ -392,7 +473,7 @@
             const delay = correct ? 800 : 1500;
             setTimeout(() => {
                 document.getElementById('feedback').textContent = '';
-                fetchActivity();
+                if (next) fetchActivity();
             }, delay);
         } catch (error) {
             console.error('Failed to submit response:', error);


### PR DESCRIPTION
## Summary
- Trigger drag-and-drop match-up when five words are warmed up in practice sessions
- Implement front-end drag-and-drop matching game for vocabulary pairs
- Track match-up completions without disrupting existing activity flow

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68c3cdc92b048325b99a8eff76804b9e