### PR TITLE
feat: enlarge prompt and add accent keyboard

### DIFF
--- a/learning/templates/learning/practice_session.html
+++ b/learning/templates/learning/practice_session.html
@@ -117,6 +117,53 @@
             border-radius: 4px;
             transition: width 0.3s ease;
         }
+        .vocab-word {
+            font-size: 32px;
+            font-weight: bold;
+            margin-bottom: 15px;
+        }
+        .accent-tab {
+            position: absolute;
+            bottom: 10px;
+            left: 50%;
+            transform: translateX(-50%);
+            background: #fff;
+            color: #000;
+            border: none;
+            border-radius: 4px;
+            padding: 6px 12px;
+            cursor: pointer;
+        }
+        .accent-panel {
+            position: absolute;
+            bottom: 50px;
+            left: 50%;
+            transform: translate(-50%, 100%);
+            background: #fff;
+            color: #000;
+            border-radius: 8px;
+            padding: 10px;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+            transition: transform 0.3s ease;
+            pointer-events: none;
+            opacity: 0;
+            z-index: 5;
+        }
+        .accent-panel.open {
+            transform: translate(-50%, 0);
+            pointer-events: auto;
+            opacity: 1;
+        }
+        .accent-panel button {
+            background: #eee;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+            padding: 5px 8px;
+            font-size: 20px;
+            cursor: pointer;
+        }
         .match-up-container {
             display: flex;
             justify-content: space-around;
@@ -157,10 +204,13 @@
     <p>Streak: <span id="streak-count">0</span> | Multiplier: x<span id="multiplier">1</span></p>
     <div id="feedback"></div>
     <div id="activity-container"></div>
+    <div id="accent-panel" class="accent-panel"></div>
+    <button id="accent-toggle" class="accent-tab">Accent Keyboard</button>
 </div>
 <script>
     document.addEventListener('DOMContentLoaded', () => {
         fetchActivity();
+        initAccentKeyboard();
     });
 
     let sessionPoints = 0;
@@ -174,6 +224,41 @@
         4: '#e91e63',
         5: '#9c27b0'
     };
+
+    function initAccentKeyboard() {
+        const accentMap = {
+            'Spanish': ['á','é','í','ó','ú','ñ','ü','¿','¡'],
+            'French': ['à','â','ä','ç','é','è','ê','ë','î','ï','ô','ö','ù','û','ü','ÿ'],
+            'German': ['ä','ö','ü','ß'],
+            'Italian': ['à','è','é','ì','ò','ù'],
+        };
+        const language = "{{ vocab_list.target_language }}";
+        const chars = accentMap[language] || [];
+        const panel = document.getElementById('accent-panel');
+        const tab = document.getElementById('accent-toggle');
+        if (chars.length === 0) {
+            tab.style.display = 'none';
+            return;
+        }
+        panel.innerHTML = chars.map(ch => `<button class="accent-key">${ch}</button>`).join('');
+        panel.querySelectorAll('.accent-key').forEach(btn => {
+            btn.addEventListener('click', () => insertAccent(btn.textContent));
+        });
+        tab.addEventListener('click', () => {
+            panel.classList.toggle('open');
+        });
+    }
+
+    function insertAccent(char) {
+        const input = document.querySelector('#typing-input, #fill-gaps-input');
+        if (!input) return;
+        const start = input.selectionStart;
+        const end = input.selectionEnd;
+        const value = input.value;
+        input.value = value.slice(0, start) + char + value.slice(end);
+        input.focus();
+        input.selectionStart = input.selectionEnd = start + char.length;
+    }
 
     async function fetchActivity() {
         try {
@@ -228,7 +313,7 @@
         const container = document.getElementById('activity-container');
         container.innerHTML = `
             <div class="show-word">
-                <p>${activity.prompt}</p>
+                <p class="vocab-word">${activity.prompt}</p>
                 <button id="reveal-word" class="btn">Show Word</button>
                 <div id="revealed-word" style="display:none; margin-top:10px;">${activity.answer}</div>
                 <div style="margin-top:10px;">
@@ -251,7 +336,7 @@
         const container = document.getElementById('activity-container');
         container.innerHTML = `
             <div class="flashcard">
-                <p>${activity.prompt}</p>
+                <p class="vocab-word">${activity.prompt}</p>
                 <button id="show-answer" class="btn">Show Answer</button>
                 <div id="answer" style="display:none; margin-top:10px;">${activity.answer}</div>
                 <div style="margin-top:10px;">
@@ -274,7 +359,7 @@
         const container = document.getElementById('activity-container');
         container.innerHTML = `
             <div class="typing">
-                <p>${activity.prompt}</p>
+                <p class="vocab-word">${activity.prompt}</p>
                 <input type="text" id="typing-input" />
                 <button id="typing-submit" class="btn">Submit</button>
             </div>
@@ -290,7 +375,7 @@
         const container = document.getElementById('activity-container');
         container.innerHTML = `
             <div class="fill-gaps">
-                <p>${activity.translation}</p>
+                <p class="vocab-word">${activity.translation}</p>
                 <p>${activity.prompt}</p>
                 <input type="text" id="fill-gaps-input" />
                 <button id="fill-gaps-submit" class="btn">Submit</button>
@@ -307,7 +392,7 @@
         const container = document.getElementById('activity-container');
         container.innerHTML = `
             <div class="multiple-choice">
-                <p>${activity.prompt}</p>
+                <p class="vocab-word">${activity.prompt}</p>
                 <div id="match-options">
                     ${activity.options.map(opt => `<button class="match-option btn">${opt}</button>`).join('')}
                 </div>
@@ -326,7 +411,7 @@
         const container = document.getElementById('activity-container');
         container.innerHTML = `
             <div class="true-false">
-                <p>${activity.prompt} - ${activity.shown_translation}</p>
+                <p><span class="vocab-word">${activity.prompt}</span> - ${activity.shown_translation}</p>
                 <button id="true-btn" class="btn">True</button>
                 <button id="false-btn" class="btn">False</button>
             </div>


### PR DESCRIPTION
## Summary
- highlight vocabulary prompts with larger font
- add slide-out accent keyboard for typing activities

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68c3d0b978f08325a13cd8c14b94e740