### PR TITLE
Display accent keys persistently in practice mode

### DIFF
--- a/learning/templates/learning/practice_session.html
+++ b/learning/templates/learning/practice_session.html
@@ -122,42 +122,19 @@
             font-weight: bold;
             margin-bottom: 15px;
         }
-        .accent-tab {
-            position: absolute;
-            bottom: 10px;
-            left: 50%;
-            transform: translateX(-50%);
-            background: #fff;
-            color: #000;
-            border: none;
-            border-radius: 4px;
-            padding: 6px 12px;
-            cursor: pointer;
-        }
         .accent-panel {
-            position: absolute;
-            bottom: 50px;
-            left: 50%;
-            transform: translate(-50%, 100%);
-            background: #fff;
-            color: #000;
+            margin: 20px auto 0;
+            background: #e0e0e0;
             border-radius: 8px;
             padding: 10px;
             display: flex;
             flex-wrap: wrap;
+            justify-content: center;
             gap: 6px;
-            transition: transform 0.3s ease;
-            pointer-events: none;
-            opacity: 0;
-            z-index: 5;
-        }
-        .accent-panel.open {
-            transform: translate(-50%, 0);
-            pointer-events: auto;
-            opacity: 1;
+            max-width: 700px;
         }
         .accent-panel button {
-            background: #eee;
+            background: #fff;
             border: 1px solid #ccc;
             border-radius: 4px;
             padding: 5px 8px;
@@ -204,9 +181,8 @@
     <p>Streak: <span id="streak-count">0</span> | Multiplier: x<span id="multiplier">1</span></p>
     <div id="feedback"></div>
     <div id="activity-container"></div>
-    <div id="accent-panel" class="accent-panel"></div>
-    <button id="accent-toggle" class="accent-tab">Accent Keyboard</button>
 </div>
+<div id="accent-panel" class="accent-panel"></div>
 <script>
     document.addEventListener('DOMContentLoaded', () => {
         fetchActivity();
@@ -227,26 +203,21 @@
 
     function initAccentKeyboard() {
         const accentMap = {
-            spanish: ['á','é','í','ó','ú','ñ','ü','¿','¡'],
-            french: ['à','â','ä','ç','é','è','ê','ë','î','ï','ô','ö','ù','û','ü','ÿ'],
-            german: ['ä','ö','ü','ß'],
-            italian: ['à','è','é','ì','ò','ù'],
+            es: ['á','é','í','ó','ú','ñ','ü','¿','¡'],
+            fr: ['à','â','ä','ç','é','è','ê','ë','î','ï','ô','ö','ù','û','ü','ÿ'],
+            de: ['ä','ö','ü','ß'],
+            it: ['à','è','é','ì','ò','ù'],
         };
         const language = "{{ vocab_list.target_language|lower }}";
-        const match = Object.keys(accentMap).find(key => language.includes(key));
-        const chars = match ? accentMap[match] : [];
+        const chars = accentMap[language] || [];
         const panel = document.getElementById('accent-panel');
-        const tab = document.getElementById('accent-toggle');
         if (chars.length === 0) {
-            tab.style.display = 'none';
+            panel.style.display = 'none';
             return;
         }
         panel.innerHTML = chars.map(ch => `<button class="accent-key">${ch}</button>`).join('');
         panel.querySelectorAll('.accent-key').forEach(btn => {
             btn.addEventListener('click', () => insertAccent(btn.textContent));
-        });
-        tab.addEventListener('click', () => {
-            panel.classList.toggle('open');
         });
     }
 


### PR DESCRIPTION
## Summary
- Replace toggleable accent keyboard with a persistent grey accent key panel under the practice session pane
- Remove accent toggle button and related JS
- Load accent characters by ISO language codes (es, fr, de, it) so German lists show the correct keys

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68c3d94e92c883258c4f8b8c33fa6dfb