### PR TITLE
Align accent keyboard beneath practice pane

### DIFF
--- a/learning/templates/learning/practice_session.html
+++ b/learning/templates/learning/practice_session.html
@@ -33,6 +33,7 @@
             padding: 0;
             background: #f5f5f5;
             display: flex;
+            flex-direction: column;
             justify-content: center;
             align-items: center;
             min-height: 100vh;


### PR DESCRIPTION
## Summary
- ensure accent keyboard sits below practice panel by stacking layout vertically

## Testing
- `python manage.py test`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3e07b759c83258dc0030e0525f4ff