### PR TITLE
Improve layout of teacher dashboard assignments pane

### DIFF
--- a/learning/templates/learning/teacher_dashboard.html
+++ b/learning/templates/learning/teacher_dashboard.html
@@ -559,63 +559,103 @@ a.btn:hover, button.btn:hover {
     <!-- Assignments Pane -->
 <div class="pane" id="assignments">
   <h2>Your Classes</h2>
-  <div id="classes-container">
-    {% for class_instance in classes %}
-      {% if request.user.is_premium or forloop.counter0 < 1 %}
-        <div class="class-item" style="margin-bottom: 20px;">
-          <div class="header" style="margin-bottom:10px;">
-            <strong>{{ class_instance.name }}</strong>
-          </div>
-          <div class="action-buttons" style="margin-bottom:10px;">
-            <button class="btn toggle-assignments" data-class-id="{{ class_instance.id }}" onclick="toggleAssignments('{{ class_instance.id }}')">Show Assignments</button>
+  <table class="assignment-table">
+    <thead>
+      <tr>
+        <th>Class Name</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for class_instance in classes %}
+        {% if request.user.is_premium or forloop.counter0 < 1 %}
+        <tr>
+          <td>{{ class_instance.name }}</td>
+          <td>
+            <button class="btn-action toggle-assignments" data-class-id="{{ class_instance.id }}" onclick="toggleAssignments('{{ class_instance.id }}')">Show Assignments</button>
             {% if request.user.is_premium %}
-              <a href="{% url 'create_assignment' class_instance.id %}" class="btn">Create Assignment</a>
+              <a href="{% url 'create_assignment' class_instance.id %}" class="btn-action">Create Assignment</a>
             {% else %}
               {% if class_instance.live_assignments|length < 1 %}
-                <a href="{% url 'create_assignment' class_instance.id %}" class="btn">Create Assignment</a>
+                <a href="{% url 'create_assignment' class_instance.id %}" class="btn-action">Create Assignment</a>
               {% else %}
                 <span class="upgrade-message">Upgrade to Premium to add more assignments</span>
               {% endif %}
             {% endif %}
-          </div>
-          <div class="assignments-container" id="assignments-{{ class_instance.id }}" style="display: none;">
+          </td>
+        </tr>
+        <tr id="assignments-{{ class_instance.id }}" class="assignments-row" style="display:none;">
+          <td colspan="2">
             <h3>Live Assignments</h3>
-            {% for assignment in class_instance.live_assignments %}
-              <div class="assignment-item" style="margin: 5px 0;">
-                <span>{{ assignment.name }} – Due: {{ assignment.deadline|date:"M d, Y H:i" }}</span>
-                {% if request.user.is_premium %}
-                  <a href="{% url 'assignment_analytics' assignment.id %}" class="btn-action" style="margin-left:10px;">Analytics</a>
-                {% else %}
-                  <span class="upgrade-message">Upgrade for Analytics</span>
-                {% endif %}
-              </div>
-            {% empty %}
-              <p>No live assignments.</p>
-            {% endfor %}
+            <table class="inner-assignment-table">
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Due Date</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for assignment in class_instance.live_assignments %}
+                <tr>
+                  <td>{{ assignment.name }}</td>
+                  <td>{{ assignment.deadline|date:"M d, Y H:i" }}</td>
+                  <td>
+                    {% if request.user.is_premium %}
+                      <a href="{% url 'assignment_analytics' assignment.id %}" class="btn-action">Analytics</a>
+                    {% else %}
+                      <span class="upgrade-message">Upgrade for Analytics</span>
+                    {% endif %}
+                  </td>
+                </tr>
+                {% empty %}
+                <tr>
+                  <td colspan="3">No live assignments.</td>
+                </tr>
+                {% endfor %}
+              </tbody>
+            </table>
 
             <h3>Expired Assignments</h3>
-            {% for assignment in class_instance.expired_assignments %}
-              <div class="assignment-item" style="margin: 5px 0;">
-                <span>{{ assignment.name }} – Expired on: {{ assignment.deadline|date:"M d, Y H:i" }}</span>
-                {% if request.user.is_premium %}
-                  <a href="{% url 'assignment_analytics' assignment.id %}" class="btn-action" style="margin-left:10px;">Analytics</a>
-                {% else %}
-                  <span class="upgrade-message">Upgrade for Analytics</span>
-                {% endif %}
-              </div>
-            {% empty %}
-              <p>No expired assignments.</p>
-            {% endfor %}
-          </div>
-        </div>
-      {% endif %}
-    {% endfor %}
-  </div>
+            <table class="inner-assignment-table">
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Expired On</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for assignment in class_instance.expired_assignments %}
+                <tr>
+                  <td>{{ assignment.name }}</td>
+                  <td>{{ assignment.deadline|date:"M d, Y H:i" }}</td>
+                  <td>
+                    {% if request.user.is_premium %}
+                      <a href="{% url 'assignment_analytics' assignment.id %}" class="btn-action">Analytics</a>
+                    {% else %}
+                      <span class="upgrade-message">Upgrade for Analytics</span>
+                    {% endif %}
+                  </td>
+                </tr>
+                {% empty %}
+                <tr>
+                  <td colspan="3">No expired assignments.</td>
+                </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </td>
+        </tr>
+        {% endif %}
+      {% endfor %}
+    </tbody>
+  </table>
 </div>
 
 
 <style>
-  .assignment-table {
+  .assignment-table, .inner-assignment-table {
     width: 100%;
     border-collapse: collapse;
     margin: 20px 0;
@@ -624,16 +664,18 @@ a.btn:hover, button.btn:hover {
     overflow: hidden;
     box-shadow: 0 4px 8px rgba(0,0,0,0.1);
   }
-  .assignment-table th, .assignment-table td {
+  .assignment-table th, .assignment-table td,
+  .inner-assignment-table th, .inner-assignment-table td {
     padding: 12px;
     text-align: center;
     border: 1px solid #ddd;
   }
-  .assignment-table th {
+  .assignment-table th, .inner-assignment-table th {
     background-color: var(--primary);
     color: #fff;
   }
-  .assignment-table tr:nth-child(even) {
+  .assignment-table tr:nth-child(even),
+  .inner-assignment-table tr:nth-child(even) {
     background-color: #f9f9f9;
   }
 
@@ -921,7 +963,7 @@ a.btn:hover, button.btn:hover {
     const button = document.querySelector(`button[data-class-id="${classId}"]`);
 
     if (container.style.display === "none" || container.style.display === "") {
-      container.style.display = "block";
+      container.style.display = "table-row";
       button.textContent = "Hide Assignments";
     } else {
       container.style.display = "none";


### PR DESCRIPTION
## Summary
- Display assignments by class in a tidy table with collapsible rows
- Add nested tables for live and expired assignments with consistent button styling
- Use JavaScript to toggle table-row visibility for assignment details

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68c3e913c7ac83259002cedcfcd99f33