### PR TITLE
feat: unify fonts across templates

### DIFF
--- a/blog/templates/blog/blog_detail.html
+++ b/blog/templates/blog/blog_detail.html
@@ -12,9 +12,11 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 
     <style>
+    @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Fredoka+One&display=swap');
+    h1 { font-family: 'Fredoka One', cursive; }
         /* General Styles */
         body {
-            font-family: Arial, sans-serif;
+            font-family: 'Poppins', sans-serif;
             margin: 0;
             padding: 0;
             min-height: 100vh;

--- a/blog/templates/blog/blog_list.html
+++ b/blog/templates/blog/blog_list.html
@@ -12,9 +12,11 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
     
     <style>
+    @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Fredoka+One&display=swap');
+    h1 { font-family: 'Fredoka One', cursive; }
         /* General Styles */
         body {
-            font-family: Arial, sans-serif;
+            font-family: 'Poppins', sans-serif;
             margin: 0;
             padding: 0;
             min-height: 100vh;

--- a/learning/templates/learning/404.html
+++ b/learning/templates/learning/404.html
@@ -6,8 +6,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Page Not Found | Pavonify</title>
     <style>
+    @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Fredoka+One&display=swap');
+    h1 { font-family: 'Fredoka One', cursive; }
         body {
-            font-family: Arial, sans-serif;
+            font-family: 'Poppins', sans-serif;
             background-color: #e3f2fd;
             color: #333;
             text-align: center;

--- a/learning/templates/learning/add_students.html
+++ b/learning/templates/learning/add_students.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Add Students to {{ class_instance.name }}</title>
   <style>
+    @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Fredoka+One&display=swap');
+    h1 { font-family: 'Fredoka One', cursive; }
     /* Global Box-Sizing */
     *, *::before, *::after {
       box-sizing: border-box;
@@ -12,7 +14,7 @@
     
     /* Base Styles */
     body {
-      font-family: Arial, sans-serif;
+      font-family: 'Poppins', sans-serif;
       background: #e3f2fd; /* Light blue/grey background */
       margin: 0;
       padding: 20px;

--- a/learning/templates/learning/add_vocabulary_list.html
+++ b/learning/templates/learning/add_vocabulary_list.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Create Vocabulary List</title>
   <style>
+    @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Fredoka+One&display=swap');
+    h1 { font-family: 'Fredoka One', cursive; }
     /* Global Box-Sizing */
     *, *::before, *::after {
       box-sizing: border-box;
@@ -12,7 +14,7 @@
     
     /* Base Styles */
     body {
-      font-family: Arial, sans-serif;
+      font-family: 'Poppins', sans-serif;
       background: #e3f2fd; /* Light blue/grey background */
       margin: 0;
       padding: 20px;

--- a/learning/templates/learning/add_vocabulary_word.html
+++ b/learning/templates/learning/add_vocabulary_word.html
@@ -1,4 +1,6 @@
 <style>
+    @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Fredoka+One&display=swap');
+    h1 { font-family: 'Fredoka One', cursive; }
   /* Global Box-Sizing */
   *, *::before, *::after {
     box-sizing: border-box;
@@ -6,7 +8,7 @@
 
   /* Base Styles */
   body {
-    font-family: Arial, sans-serif;
+    font-family: 'Poppins', sans-serif;
     background: #e3f2fd; /* Light blue/grey background */
     margin: 0;
     padding: 20px;

--- a/learning/templates/learning/add_words_to_list.html
+++ b/learning/templates/learning/add_words_to_list.html
@@ -1,4 +1,6 @@
 <style>
+    @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Fredoka+One&display=swap');
+    h1 { font-family: 'Fredoka One', cursive; }
   /* Global Box-Sizing */
   *, *::before, *::after {
     box-sizing: border-box;
@@ -6,7 +8,7 @@
 
   /* Base Styles */
   body {
-    font-family: Arial, sans-serif;
+    font-family: 'Poppins', sans-serif;
     background: #e3f2fd; /* Light blue/grey background */
     margin: 0;
     padding: 20px;

--- a/learning/templates/learning/assignment_modes/destroy_the_wall_assignment.html
+++ b/learning/templates/learning/assignment_modes/destroy_the_wall_assignment.html
@@ -4,9 +4,11 @@
     <meta charset="UTF-8">
     <title>Destroy the Wall</title>
     <style>
+    @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Fredoka+One&display=swap');
+    h1 { font-family: 'Fredoka One', cursive; }
         /* Your existing CSS styling */
         body {
-            font-family: Arial, sans-serif;
+            font-family: 'Poppins', sans-serif;
             text-align: center;
             margin: 0;
             padding: 0;

--- a/learning/templates/learning/assignment_modes/flashcard_mode_assignment.html
+++ b/learning/templates/learning/assignment_modes/flashcard_mode_assignment.html
@@ -5,9 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Flashcard Mode</title>
     <style>
+    @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Fredoka+One&display=swap');
+    h1 { font-family: 'Fredoka One', cursive; }
 
 body {
-    font-family: Arial, sans-serif;
+    font-family: 'Poppins', sans-serif;
     background-color: #f9f9f9;
     align-items: center;
     text-align: center;

--- a/learning/templates/learning/assignment_modes/gap_fill_mode_assignment.html
+++ b/learning/templates/learning/assignment_modes/gap_fill_mode_assignment.html
@@ -5,8 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Gap-Fill Mode</title>
     <style>
+    @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Fredoka+One&display=swap');
+    h1 { font-family: 'Fredoka One', cursive; }
         body {
-            font-family: Arial, sans-serif;
+            font-family: 'Poppins', sans-serif;
             margin: 0;
             padding: 0;
             background-color: #f9f9f9;

--- a/learning/templates/learning/assignment_modes/listening_dictation_assignment.html
+++ b/learning/templates/learning/assignment_modes/listening_dictation_assignment.html
@@ -6,9 +6,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Listening Dictation - Assignment Mode</title>
   <style>
+    @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Fredoka+One&display=swap');
+    h1 { font-family: 'Fredoka One', cursive; }
     /* Global Styles */
     body {
-      font-family: Arial, sans-serif;
+      font-family: 'Poppins', sans-serif;
       margin: 0;
       background: #e3f2fd;
       display: flex;

--- a/learning/templates/learning/assignment_modes/listening_translation_assignment.html
+++ b/learning/templates/learning/assignment_modes/listening_translation_assignment.html
@@ -6,9 +6,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Translation Mode - Assignment</title>
   <style>
+    @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Fredoka+One&display=swap');
+    h1 { font-family: 'Fredoka One', cursive; }
     /* Global Styles */
     body {
-      font-family: Arial, sans-serif;
+      font-family: 'Poppins', sans-serif;
       margin: 0;
       background: #e3f2fd;
       display: flex;

--- a/learning/templates/learning/assignment_modes/match_up_mode_assignment.html
+++ b/learning/templates/learning/assignment_modes/match_up_mode_assignment.html
@@ -5,8 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Match Up Mode</title>
   <style>
+    @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Fredoka+One&display=swap');
+    h1 { font-family: 'Fredoka One', cursive; }
     body {
-      font-family: Arial, sans-serif;
+      font-family: 'Poppins', sans-serif;
     }
     h1 {
       text-align: center;

--- a/learning/templates/learning/assignment_modes/unscramble_the_word_assignment.html
+++ b/learning/templates/learning/assignment_modes/unscramble_the_word_assignment.html
@@ -6,8 +6,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Unscramble the Word</title>
   <style>
+    @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Fredoka+One&display=swap');
+    h1 { font-family: 'Fredoka One', cursive; }
     body {
-      font-family: Arial, sans-serif;
+      font-family: 'Poppins', sans-serif;
       margin: 0;
       padding: 0;
       text-align: center;

--- a/learning/templates/learning/assignment_practice_session.html
+++ b/learning/templates/learning/assignment_practice_session.html
@@ -27,8 +27,10 @@
         })();
     </script>
     <style>
+    @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Fredoka+One&display=swap');
+    h1 { font-family: 'Fredoka One', cursive; }
         body {
-            font-family: Arial, sans-serif;
+            font-family: 'Poppins', sans-serif;
             margin: 0;
             padding: 0;
             background: #f5f5f5;

--- a/learning/templates/learning/create_assignment.html
+++ b/learning/templates/learning/create_assignment.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Create Assignment</title>
   <style>
+    @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Fredoka+One&display=swap');
+    h1 { font-family: 'Fredoka One', cursive; }
     /* Global Box-Sizing */
     *, *::before, *::after {
       box-sizing: border-box;
@@ -12,7 +14,7 @@
 
     /* Base Styles */
     body {
-      font-family: Arial, sans-serif;
+      font-family: 'Poppins', sans-serif;
       background: #e3f2fd;  /* Light blue/grey background */
       margin: 0;
       padding: 20px;

--- a/learning/templates/learning/create_class.html
+++ b/learning/templates/learning/create_class.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Create Class</title>
   <style>
+    @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Fredoka+One&display=swap');
+    h1 { font-family: 'Fredoka One', cursive; }
     /* Global Box-Sizing */
     *, *::before, *::after {
       box-sizing: border-box;
@@ -12,7 +14,7 @@
     
     /* Base Styles */
     body {
-      font-family: Arial, sans-serif;
+      font-family: 'Poppins', sans-serif;
       background: #e3f2fd; /* Light blue/grey background */
       margin: 0;
       padding: 20px;

--- a/learning/templates/learning/delete_vocabulary_list.html
+++ b/learning/templates/learning/delete_vocabulary_list.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Delete Vocabulary List</title>
   <style>
+    @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Fredoka+One&display=swap');
+    h1 { font-family: 'Fredoka One', cursive; }
     /* Global box-sizing */
     *, *::before, *::after {
       box-sizing: border-box;
@@ -12,7 +14,7 @@
     
     /* Base styles */
     body {
-      font-family: Arial, sans-serif;
+      font-family: 'Poppins', sans-serif;
       background: #e3f2fd;
       margin: 0;
       padding: 20px;

--- a/learning/templates/learning/destroy_the_wall.html
+++ b/learning/templates/learning/destroy_the_wall.html
@@ -6,9 +6,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Destroy the Wall - Pavonify</title>
   <style>
+    @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Fredoka+One&display=swap');
+    h1 { font-family: 'Fredoka One', cursive; }
     /* Global Styles */
     body {
-      font-family: Arial, sans-serif;
+      font-family: 'Poppins', sans-serif;
       margin: 0;
       background: #e3f2fd;
       display: flex;

--- a/learning/templates/learning/edit_class.html
+++ b/learning/templates/learning/edit_class.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Edit Class - {{ class_instance.name }}</title>
   <style>
+    @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Fredoka+One&display=swap');
+    h1 { font-family: 'Fredoka One', cursive; }
     /* Global Box-Sizing */
     *, *::before, *::after {
       box-sizing: border-box;
@@ -12,7 +14,7 @@
     
     /* Base Styles */
     body {
-      font-family: Arial, sans-serif;
+      font-family: 'Poppins', sans-serif;
       background: #e3f2fd; /* Light blue/grey background */
       margin: 0;
       padding: 20px;

--- a/learning/templates/learning/edit_vocabulary_list_details.html
+++ b/learning/templates/learning/edit_vocabulary_list_details.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Edit Vocabulary List</title>
   <style>
+    @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Fredoka+One&display=swap');
+    h1 { font-family: 'Fredoka One', cursive; }
     /* Global Box-Sizing */
     *, *::before, *::after {
       box-sizing: border-box;
@@ -12,7 +14,7 @@
 
     /* Base Styles */
     body {
-      font-family: Arial, sans-serif;
+      font-family: 'Poppins', sans-serif;
       background: #e3f2fd; /* Light blue/grey background */
       margin: 0;
       padding: 20px;

--- a/learning/templates/learning/edit_vocabulary_words.html
+++ b/learning/templates/learning/edit_vocabulary_words.html
@@ -6,6 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Edit Words for "{{ vocab_list.name }}"</title>
   <style>
+    @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Fredoka+One&display=swap');
+    h1 { font-family: 'Fredoka One', cursive; }
     /* Global Box-Sizing */
     *, *::before, *::after {
       box-sizing: border-box;
@@ -13,7 +15,7 @@
     
     /* Base Styles */
     body {
-      font-family: Arial, sans-serif;
+      font-family: 'Poppins', sans-serif;
       background: #e3f2fd;
       margin: 0;
       padding: 20px;

--- a/learning/templates/learning/flashcard_mode.html
+++ b/learning/templates/learning/flashcard_mode.html
@@ -6,9 +6,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Flashcard Mode - Pavonify</title>
   <style>
+    @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Fredoka+One&display=swap');
+    h1 { font-family: 'Fredoka One', cursive; }
     /* Global Styles */
     body {
-      font-family: Arial, sans-serif;
+      font-family: 'Poppins', sans-serif;
       margin: 0;
       background: #e3f2fd;
       display: flex;

--- a/learning/templates/learning/gap_fill_mode.html
+++ b/learning/templates/learning/gap_fill_mode.html
@@ -6,9 +6,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Gap-Fill Mode - Pavonify</title>
   <style>
+    @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Fredoka+One&display=swap');
+    h1 { font-family: 'Fredoka One', cursive; }
     /* Global Styles */
     body {
-      font-family: Arial, sans-serif;
+      font-family: 'Poppins', sans-serif;
       margin: 0;
       background: #e3f2fd;
       display: flex;

--- a/learning/templates/learning/listening_dictation.html
+++ b/learning/templates/learning/listening_dictation.html
@@ -6,9 +6,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Listening Dictation - Pavonify</title>
   <style>
+    @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Fredoka+One&display=swap');
+    h1 { font-family: 'Fredoka One', cursive; }
     /* Global Styles */
     body {
-      font-family: Arial, sans-serif;
+      font-family: 'Poppins', sans-serif;
       margin: 0;
       background: #e3f2fd;
       display: flex;

--- a/learning/templates/learning/listening_translation.html
+++ b/learning/templates/learning/listening_translation.html
@@ -6,9 +6,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Translation Mode - Pavonify</title>
   <style>
+    @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Fredoka+One&display=swap');
+    h1 { font-family: 'Fredoka One', cursive; }
     /* Global Styles */
     body {
-      font-family: Arial, sans-serif;
+      font-family: 'Poppins', sans-serif;
       margin: 0;
       background: #e3f2fd;
       display: flex;

--- a/learning/templates/learning/match_up_mode.html
+++ b/learning/templates/learning/match_up_mode.html
@@ -6,9 +6,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Match Up Mode - Pavonify</title>
   <style>
+    @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Fredoka+One&display=swap');
+    h1 { font-family: 'Fredoka One', cursive; }
     /* Global Styles */
     body {
-      font-family: Arial, sans-serif;
+      font-family: 'Poppins', sans-serif;
       margin: 0;
       background: #e3f2fd;
       display: flex;

--- a/learning/templates/learning/payment_success.html
+++ b/learning/templates/learning/payment_success.html
@@ -5,8 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Payment Successful</title>
     <style>
+    @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Fredoka+One&display=swap');
+    h1 { font-family: 'Fredoka One', cursive; }
         body {
-            font-family: Arial, sans-serif;
+            font-family: 'Poppins', sans-serif;
             text-align: center;
             padding: 50px;
         }

--- a/learning/templates/learning/practice_session.html
+++ b/learning/templates/learning/practice_session.html
@@ -27,8 +27,10 @@
         })();
     </script>
     <style>
+    @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Fredoka+One&display=swap');
+    h1 { font-family: 'Fredoka One', cursive; }
         body {
-            font-family: Arial, sans-serif;
+            font-family: 'Poppins', sans-serif;
             margin: 0;
             padding: 0;
             background: #f5f5f5;

--- a/learning/templates/learning/reading_lab_display.html
+++ b/learning/templates/learning/reading_lab_display.html
@@ -6,8 +6,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Generated Parallel Text & Activities</title>
     <style>
+    @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Fredoka+One&display=swap');
+    h1 { font-family: 'Fredoka One', cursive; }
         body {
-            font-family: Arial, sans-serif;
+            font-family: 'Poppins', sans-serif;
             margin: 0;
             min-height: 100vh;
             background: #e3f2fd;

--- a/learning/templates/learning/unscramble_the_word.html
+++ b/learning/templates/learning/unscramble_the_word.html
@@ -6,9 +6,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Unscramble the Word - Pavonify</title>
   <style>
+    @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Fredoka+One&display=swap');
+    h1 { font-family: 'Fredoka One', cursive; }
     /* Global Styles */
     body {
-      font-family: Arial, sans-serif;
+      font-family: 'Poppins', sans-serif;
       margin: 0;
       background: #e3f2fd;
       display: flex;

--- a/learning/templates/learning/view_attached_vocab.html
+++ b/learning/templates/learning/view_attached_vocab.html
@@ -6,9 +6,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Attached Vocabulary Lists</title>
   <style>
+    @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Fredoka+One&display=swap');
+    h1 { font-family: 'Fredoka One', cursive; }
     /* (Your styles can remain mostly the same) */
     body {
-      font-family: Arial, sans-serif;
+      font-family: 'Poppins', sans-serif;
       background: #e3f2fd;
       margin: 0;
       padding: 20px;

--- a/learning/templates/learning/view_vocabulary_words.html
+++ b/learning/templates/learning/view_vocabulary_words.html
@@ -6,6 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Vocabulary List: {{ vocab_list.name }}</title>
   <style>
+    @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Fredoka+One&display=swap');
+    h1 { font-family: 'Fredoka One', cursive; }
     /* Global Box-Sizing */
     *, *::before, *::after {
       box-sizing: border-box;
@@ -13,7 +15,7 @@
     
     /* Base Styles */
     body {
-      font-family: Arial, sans-serif;
+      font-family: 'Poppins', sans-serif;
       background: #e3f2fd;
       margin: 0;
       padding: 20px;

--- a/static/css/global.css
+++ b/static/css/global.css
@@ -1,8 +1,17 @@
 @import url('https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css');
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Fredoka+One&display=swap');
+
+body {
+    font-family: 'Poppins', sans-serif;
+}
+
+h1 {
+    font-family: 'Fredoka One', cursive;
+}
 
 /* Layout for dashboard pages */
 .dashboard-layout {
-    font-family: Arial, sans-serif;
+    font-family: 'Poppins', sans-serif;
     display: flex;
     margin: 0;
     min-height: 100vh;


### PR DESCRIPTION
## Summary
- import Poppins and Fredoka One globally and set base fonts
- update templates to use Poppins for body copy
- ensure page titles use Fredoka One for consistent branding

## Testing
- `python manage.py test`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3eb4742808325bbb7ea8fcd8405e7