### PR TITLE
Improve bulk word addition performance and validation

### DIFF
--- a/learning/forms.py
+++ b/learning/forms.py
@@ -76,6 +76,30 @@ class BulkAddWordsForm(forms.Form):
         help_text="Add words in the format: word,translation (one pair per line)."
     )
 
+    MAX_WORDS = 100
+    MAX_LENGTH = 100
+
+    def clean_words(self):
+        """Validate and normalize bulk word input."""
+        raw = self.cleaned_data["words"]
+        lines = [line.strip() for line in raw.splitlines() if line.strip()]
+
+        if len(lines) > self.MAX_WORDS:
+            raise forms.ValidationError(
+                f"You can only add up to {self.MAX_WORDS} words at once."
+            )
+
+        pairs = []
+        for line in lines:
+            if "," not in line:
+                continue
+            word, translation = [
+                part.strip()[: self.MAX_LENGTH] for part in line.split(",", 1)
+            ]
+            pairs.append((word, translation))
+
+        return pairs
+
 class ClassForm(forms.ModelForm):
     language = forms.ChoiceField(choices=LANGUAGE_CHOICES)  # Add dropdown
 

--- a/learning/views.py
+++ b/learning/views.py
@@ -214,19 +214,22 @@ def add_words_to_list(request, list_id):
     if request.method == 'POST':
         form = BulkAddWordsForm(request.POST)
         if form.is_valid():
-            words_input = form.cleaned_data['words']
-            words_pairs = [line.split(',') for line in words_input.splitlines() if ',' in line]
-            for word, translation in words_pairs:
-                VocabularyWord.objects.create(
-                    list=vocab_list,
-                    word=word.strip(),
-                    translation=translation.strip()
-                )
+            word_pairs = form.cleaned_data['words']
+            vocab_words = [
+                VocabularyWord(list=vocab_list, word=w, translation=t)
+                for w, t in word_pairs
+                if w and t
+            ]
+            VocabularyWord.objects.bulk_create(vocab_words)
             messages.success(request, "Words added successfully!")
             return redirect('teacher_dashboard')
     else:
         form = BulkAddWordsForm()
-    return render(request, 'learning/add_words_to_list.html', {'form': form, 'vocab_list': vocab_list})
+    return render(
+        request,
+        'learning/add_words_to_list.html',
+        {'form': form, 'vocab_list': vocab_list},
+    )
 
 
 @login_required


### PR DESCRIPTION
## Summary
- Add `clean_words` to `BulkAddWordsForm` for enforcing entry limits and trimming words
- Use `VocabularyWord.objects.bulk_create` in `add_words_to_list` to reduce DB calls

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68c7cf4a27c08325b2d588a32c8e287a