### PR TITLE
Add student filtering and sorting to teacher dashboard

### DIFF
--- a/learning/templates/learning/teacher_dashboard.html
+++ b/learning/templates/learning/teacher_dashboard.html
@@ -534,6 +534,23 @@ a.btn:hover, button.btn:hover {
     <!-- Students Pane -->
     <div class="pane" id="students">
       <h2>Students</h2>
+      <form method="get" class="student-filter-form">
+        <input type="hidden" name="pane" value="students">
+        <label for="class_id">Class:</label>
+        <select name="class_id" id="class_id" onchange="this.form.submit()">
+          <option value="">All Classes</option>
+          {% for class_instance in classes %}
+          <option value="{{ class_instance.id }}" {% if class_instance.id|stringformat:'s' == selected_class_id %}selected{% endif %}>{{ class_instance.name }}</option>
+          {% endfor %}
+        </select>
+
+        <label for="sort">Sort by:</label>
+        <select name="sort" id="sort" onchange="this.form.submit()">
+          <option value="last_login" {% if sort_by == 'last_login' %}selected{% endif %}>Last Login</option>
+          <option value="alphabetical" {% if sort_by == 'alphabetical' %}selected{% endif %}>Alphabetical</option>
+          <option value="points" {% if sort_by == 'points' %}selected{% endif %}>Total Points</option>
+        </select>
+      </form>
       <table id="students-table">
         <thead>
           <tr>
@@ -1016,6 +1033,16 @@ a.btn:hover, button.btn:hover {
     // Navigation: Switch content panes when clicking on nav links (top-nav and dropdown)
     const navLinks = document.querySelectorAll(".top-nav .nav-right a, .dropdown-content a");
     const panes = document.querySelectorAll(".pane");
+
+    // Show pane based on URL parameter if provided
+    const params = new URLSearchParams(window.location.search);
+    const initialPane = params.get("pane");
+    if (initialPane) {
+      navLinks.forEach(l => l.classList.remove("active"));
+      panes.forEach(pane => pane.classList.remove("active"));
+      document.getElementById(initialPane)?.classList.add("active");
+      document.querySelector(`[data-pane="${initialPane}"]`)?.classList.add("active");
+    }
 
     navLinks.forEach(link => {
       link.addEventListener("click", e => {

--- a/learning/views.py
+++ b/learning/views.py
@@ -116,7 +116,21 @@ def teacher_dashboard(request):
     reading_lab_texts = ReadingLabText.objects.filter(teacher=request.user).order_by('-created_at')
     vocab_lists = VocabularyList.objects.filter(teacher=request.user)
     classes = Class.objects.filter(teachers=request.user).distinct()
+
+    # --- Student filtering and sorting ---
+    selected_class_id = request.GET.get("class_id")
+    sort_by = request.GET.get("sort", "alphabetical")
+
     students = Student.objects.filter(classes__in=classes).distinct()
+    if selected_class_id:
+        students = students.filter(classes__id=selected_class_id)
+
+    if sort_by == "last_login":
+        students = students.order_by("-last_login")
+    elif sort_by == "points":
+        students = students.order_by("-total_points")
+    else:  # alphabetical
+        students = students.order_by("last_name", "first_name")
 
     # Annotate each class with live and expired assignments
     for class_instance in classes:
@@ -162,6 +176,8 @@ def teacher_dashboard(request):
         "vocab_lists": vocab_lists,
         "classes": classes,
         "students": students,
+        "selected_class_id": selected_class_id,
+        "sort_by": sort_by,
         "announcements": announcements,
         "reading_lab_texts": reading_lab_texts,
         "overall_leaderboard_page": overall_leaderboard_page,


### PR DESCRIPTION
## Summary
- Allow teachers to filter students by class and sort by last login, name, or total points
- Add UI controls for filtering and sorting on the dashboard
- Keep the Students pane active when filtering via URL parameter

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68c7d94335188325b37d4dd7751de755