### PR TITLE
Enhance enrichment preview with translation-aware facts

### DIFF
--- a/frontend/src/components/BulkAddEnrichmentPreview.tsx
+++ b/frontend/src/components/BulkAddEnrichmentPreview.tsx
@@ -28,19 +28,28 @@ type Fact = {
 
 type Row = {
   word: string;
+  translation?: string;
   images: ImageCandidate[];
   fact: Fact;
 };
 
+type WordEntry = {
+  word: string;
+  translation?: string;
+  factType?: Fact["type"];
+};
+
+type FactCache = Record<string, Partial<Record<Fact["type"], Fact>>>;
+
 type Props = {
-  words: string[];
+  entries: WordEntry[];
   listId: number;
   onClose: () => void;
   fetchImpl?: typeof fetch;
 };
 
 export default function BulkAddEnrichmentPreview({
-  words,
+  entries,
   listId,
   onClose,
   fetchImpl = fetch,
@@ -54,10 +63,27 @@ export default function BulkAddEnrichmentPreview({
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [refreshingWord, setRefreshingWord] = useState<string | null>(null);
+  const [factCache, setFactCache] = useState<FactCache>({});
 
   const fetchPreviewFor = useCallback(
-    async (targetWords: string[]): Promise<Row[]> => {
-      if (!targetWords.length) {
+    async (targetEntries: WordEntry[]): Promise<Row[]> => {
+      const payloadEntries = (targetEntries || [])
+        .map(item => {
+          const word = (item.word || "").trim();
+          if (!word) {
+            return null;
+          }
+          const translation = (item.translation || "").trim();
+          const factType = item.factType;
+          return {
+            word,
+            translation,
+            fact_type: factType && ["etymology", "idiom", "trivia"].includes(factType) ? factType : undefined,
+          };
+        })
+        .filter((entry): entry is { word: string; translation: string; fact_type?: Fact["type"] } => Boolean(entry));
+
+      if (!payloadEntries.length) {
         return [];
       }
 
@@ -71,7 +97,10 @@ export default function BulkAddEnrichmentPreview({
         method: "POST",
         headers,
         credentials: "include",
-        body: JSON.stringify({ words: targetWords }),
+        body: JSON.stringify({
+          list_id: listId,
+          entries: payloadEntries,
+        }),
       });
 
       let data: unknown = null;
@@ -96,16 +125,24 @@ export default function BulkAddEnrichmentPreview({
 
       return data as Row[];
     },
-    [fetchImpl]
+    [fetchImpl, listId]
   );
 
   const applyInitialRows = useCallback((rowsData: Row[]) => {
     const initSel: Record<string, ImageCandidate | null> = {};
     const initFact: Record<string, Fact> = {};
+    const initCache: FactCache = {};
 
     rowsData.forEach(item => {
       initSel[item.word] = item.images[0] || null;
       initFact[item.word] = { ...item.fact };
+      if (item.fact?.type) {
+        initCache[item.word] = {
+          [item.fact.type]: { ...item.fact },
+        };
+      } else {
+        initCache[item.word] = {};
+      }
     });
 
     setRows(rowsData);
@@ -113,6 +150,7 @@ export default function BulkAddEnrichmentPreview({
     setFactEdits(initFact);
     setApproveImage({});
     setApproveFact({});
+    setFactCache(initCache);
   }, []);
 
   const replaceRow = useCallback((word: string, updatedRow: Row) => {
@@ -143,6 +181,15 @@ export default function BulkAddEnrichmentPreview({
     setFactEdits(prev => ({ ...prev, [cleanedWord]: { ...nextRow.fact } }));
     setApproveImage(prev => ({ ...prev, [cleanedWord]: false }));
     setApproveFact(prev => ({ ...prev, [cleanedWord]: false }));
+    setFactCache(prev => {
+      const next = { ...prev };
+      const existing = { ...(next[cleanedWord] || {}) };
+      if (nextRow.fact?.type) {
+        existing[nextRow.fact.type] = { ...nextRow.fact };
+      }
+      next[cleanedWord] = existing;
+      return next;
+    });
   }, []);
 
   useEffect(() => {
@@ -152,7 +199,7 @@ export default function BulkAddEnrichmentPreview({
       try {
         setError(null);
         setLoading(true);
-        const rowsData = await fetchPreviewFor(words);
+        const rowsData = await fetchPreviewFor(entries);
         if (!active) {
           return;
         }
@@ -166,6 +213,7 @@ export default function BulkAddEnrichmentPreview({
         setFactEdits({});
         setApproveImage({});
         setApproveFact({});
+        setFactCache({});
         setError(err?.message || "Failed to load preview");
       } finally {
         if (active) {
@@ -177,61 +225,123 @@ export default function BulkAddEnrichmentPreview({
     return () => {
       active = false;
     };
-  }, [words, fetchPreviewFor, applyInitialRows]);
+  }, [entries, fetchPreviewFor, applyInitialRows]);
 
-  const refreshWord = async (word: string) => {
-    if (!word) {
-      return;
-    }
-
-    try {
-      setError(null);
-      setRefreshingWord(word);
-      const rowsData = await fetchPreviewFor([word]);
-      const normalized = word.trim().toLowerCase();
-      const updatedRow =
-        rowsData.find(item => item.word.trim().toLowerCase() === normalized) || rowsData[0] || null;
-      if (!updatedRow) {
-        throw new Error("No enrichment suggestions returned.");
+  const refreshWord = useCallback(
+    async (word: string, factType?: Fact["type"]) => {
+      if (!word) {
+        return;
       }
-      replaceRow(word, updatedRow);
-    } catch (err: any) {
-      setError(err?.message || "Failed to refresh suggestions");
-    } finally {
-      setRefreshingWord(null);
-    }
-  };
 
-  const reloadAll = async () => {
-    if (!words.length) {
+      const existingRow = rows.find(item => item.word === word);
+      const fallbackEntry = entries.find(item => item.word === word);
+      const translation = existingRow?.translation || fallbackEntry?.translation || "";
+
+      try {
+        setError(null);
+        setRefreshingWord(word);
+        const rowsData = await fetchPreviewFor([
+          { word, translation, factType },
+        ]);
+        const normalized = word.trim().toLowerCase();
+        const updatedRow =
+          rowsData.find(item => item.word.trim().toLowerCase() === normalized) || rowsData[0] || null;
+        if (!updatedRow) {
+          throw new Error("No enrichment suggestions returned.");
+        }
+        const patchedRow: Row = {
+          ...updatedRow,
+          translation: updatedRow.translation || translation,
+        };
+        replaceRow(word, patchedRow);
+      } catch (err: any) {
+        setError(err?.message || "Failed to refresh suggestions");
+      } finally {
+        setRefreshingWord(null);
+      }
+    },
+    [entries, fetchPreviewFor, replaceRow, rows]
+  );
+
+  const reloadAll = useCallback(async () => {
+    const requestEntries: WordEntry[] = rows.length
+      ? rows.map(row => ({
+          word: row.word,
+          translation: row.translation || entries.find(item => item.word === row.word)?.translation || "",
+          factType: (factEdits[row.word]?.type || row.fact.type) as Fact["type"],
+        }))
+      : entries;
+
+    if (!requestEntries.length) {
       return;
     }
 
     try {
       setError(null);
       setLoading(true);
-      const rowsData = await fetchPreviewFor(words);
+      const rowsData = await fetchPreviewFor(requestEntries);
       applyInitialRows(rowsData);
     } catch (err: any) {
       setError(err?.message || "Failed to refresh suggestions");
     } finally {
       setLoading(false);
     }
-  };
+  }, [applyInitialRows, entries, factEdits, fetchPreviewFor, rows]);
 
   const resetFactToSuggestion = (word: string) => {
     const row = rows.find(item => item.word === word);
     if (!row) {
       return;
     }
-    setFactEdits(prev => ({ ...prev, [word]: { ...row.fact } }));
+    const currentType = (factEdits[word]?.type || row.fact.type || "trivia") as Fact["type"];
+    const cached = factCache[word]?.[currentType];
     setApproveFact(prev => ({ ...prev, [word]: false }));
+    if (cached) {
+      setFactEdits(prev => ({ ...prev, [word]: { ...cached } }));
+      return;
+    }
+    setFactEdits(prev => ({
+      ...prev,
+      [word]: {
+        ...(prev[word] || {}),
+        type: currentType,
+        text: "",
+        confidence: prev[word]?.confidence ?? row.fact.confidence,
+      },
+    }));
+    void refreshWord(word, currentType);
   };
 
   const clearImageSelection = (word: string) => {
     setSelectedImage(prev => ({ ...prev, [word]: null }));
     setApproveImage(prev => ({ ...prev, [word]: false }));
   };
+
+  const handleFactTypeChange = useCallback(
+    (word: string, nextType: Fact["type"]) => {
+      if (!word || !nextType) {
+        return;
+      }
+      const baseRow = rows.find(item => item.word === word);
+      setFactEdits(prev => {
+        const current = { ...(prev[word] || {}) } as Fact;
+        current.type = nextType;
+        current.text = "";
+        if (typeof current.confidence !== "number") {
+          current.confidence = baseRow?.fact.confidence;
+        }
+        return { ...prev, [word]: current };
+      });
+      setApproveFact(prev => ({ ...prev, [word]: false }));
+      const cached = factCache[word]?.[nextType];
+      if (cached) {
+        setFactEdits(prev => ({ ...prev, [word]: { ...cached } }));
+        return;
+      }
+      void refreshWord(word, nextType);
+    },
+    [factCache, refreshWord, rows]
+  );
 
   const onConfirm = async () => {
     try {
@@ -319,12 +429,15 @@ export default function BulkAddEnrichmentPreview({
           return (
             <section key={row.word} className="enrichment-card">
               <div className="enrichment-card-header">
-                <h3 className="enrichment-card-title">{row.word}</h3>
+                <h3 className="enrichment-card-title">
+                  {row.word}
+                  {row.translation ? ` (${row.translation})` : ""}
+                </h3>
                 <div className="enrichment-card-actions">
                   <button
                     type="button"
                     className="enrichment-button enrichment-button--ghost"
-                    onClick={() => refreshWord(row.word)}
+                    onClick={() => refreshWord(row.word, factType)}
                     disabled={isRefreshing || disableGlobalActions}
                   >
                     {isRefreshing ? "Refreshing…" : "New suggestions"}
@@ -421,22 +534,14 @@ export default function BulkAddEnrichmentPreview({
                         },
                       }))
                     }
+                    disabled={isRefreshing}
                   />
                   <div className="enrichment-fact-footer">
                     <span>{factValue.length}/220 characters</span>
                     <select
                       value={factType}
-                      onChange={e =>
-                        setFactEdits(prev => ({
-                          ...prev,
-                          [row.word]: {
-                            ...(prev[row.word] || { text: factValue }),
-                            type: e.target.value as Fact["type"],
-                            text: factValue,
-                            confidence: factConfidence,
-                          },
-                        }))
-                      }
+                      onChange={e => handleFactTypeChange(row.word, e.target.value as Fact["type"])}
+                      disabled={isRefreshing || disableGlobalActions}
                     >
                       <option value="etymology">etymology</option>
                       <option value="idiom">idiom</option>

--- a/learning/api/enrichment.py
+++ b/learning/api/enrichment.py
@@ -5,13 +5,23 @@ from typing import Any, Dict, List
 from rest_framework import permissions, serializers, status, views
 from rest_framework.response import Response
 
-from learning.models import VocabularyWord
+from django.shortcuts import get_object_or_404
+
+from learning.models import VocabularyList, VocabularyWord
 from learning.services.enrichment import get_enrichments
 
+class PreviewEntrySerializer(serializers.Serializer):
+    word = serializers.CharField(allow_blank=False, trim_whitespace=True, max_length=100)
+    translation = serializers.CharField(required=False, allow_blank=True, trim_whitespace=True, max_length=100)
+    fact_type = serializers.ChoiceField(choices=("etymology", "idiom", "trivia"), required=False)
+
+
 class PreviewRequestSerializer(serializers.Serializer):
-    words = serializers.ListField(
-        child=serializers.CharField(allow_blank=False, trim_whitespace=True),
-        min_length=1, max_length=200
+    list_id = serializers.IntegerField()
+    entries = serializers.ListField(
+        child=PreviewEntrySerializer(),
+        min_length=1,
+        max_length=200,
     )
 
 class ImagePayloadSerializer(serializers.Serializer):
@@ -43,8 +53,16 @@ class EnrichmentPreviewAPI(views.APIView):
     def post(self, request, *args, **kwargs):
         ser = PreviewRequestSerializer(data=request.data)
         ser.is_valid(raise_exception=True)
-        words: List[str] = ser.validated_data["words"]
-        data = get_enrichments(words)
+        list_id: int = ser.validated_data["list_id"]
+        entries: List[Dict[str, Any]] = ser.validated_data["entries"]
+
+        vocab_list = get_object_or_404(VocabularyList, id=list_id, teacher=request.user)
+
+        data = get_enrichments(
+            entries,
+            source_language=vocab_list.source_language,
+            target_language=vocab_list.target_language,
+        )
         return Response(data, status=status.HTTP_200_OK)
 
 class EnrichmentConfirmAPI(views.APIView):

--- a/learning/management/commands/test_gemini_facts.py
+++ b/learning/management/commands/test_gemini_facts.py
@@ -11,11 +11,47 @@ class Command(BaseCommand):
             type=str,
             help="The word you want a Gemini fact for (e.g. 'Dog')",
         )
+        parser.add_argument(
+            "--translation",
+            type=str,
+            default="",
+            help="Optional translation of the word in the teacher's source language.",
+        )
+        parser.add_argument(
+            "--source-lang",
+            type=str,
+            default="",
+            help="Source language code (e.g. en).",
+        )
+        parser.add_argument(
+            "--target-lang",
+            type=str,
+            default="",
+            help="Target language code (e.g. de).",
+        )
+        parser.add_argument(
+            "--fact-type",
+            type=str,
+            default="",
+            choices=["", "etymology", "idiom", "trivia"],
+            help="Optional fact type to request.",
+        )
 
     def handle(self, *args, **options):
         word = options["word"]
+        translation = options.get("translation") or ""
+        source_lang = options.get("source_lang") or ""
+        target_lang = options.get("target_lang") or ""
+        fact_type = options.get("fact_type") or ""
+
         self.stdout.write(self.style.NOTICE(f"Requesting Gemini fact for: {word}"))
-        fact = get_fact(word)
+        fact = get_fact(
+            word,
+            translation=translation,
+            source_language=source_lang or None,
+            target_language=target_lang or None,
+            preferred_type=fact_type or None,
+        )
         if not fact["text"]:
             self.stdout.write(self.style.WARNING("❌ No fact returned"))
         else:

--- a/learning/services/enrichment.py
+++ b/learning/services/enrichment.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor, wait, FIRST_COMPLETED
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 import logging
 import os
 import time
@@ -14,8 +14,10 @@ logger = logging.getLogger(__name__)
 
 # Tunables (can override via env)
 PER_WORD_TIMEOUT = float(os.getenv("ENRICH_TIMEOUT_PER_WORD", "6.0"))   # seconds for images/fact each
-MAX_THREADS      = int(os.getenv("ENRICH_MAX_THREADS", "8"))            # overall concurrency cap
-IMG_LIMIT        = int(os.getenv("ENRICH_IMG_LIMIT", "3"))
+MAX_THREADS = int(os.getenv("ENRICH_MAX_THREADS", "8"))  # overall concurrency cap
+IMG_LIMIT = int(os.getenv("ENRICH_IMG_LIMIT", "3"))
+
+_FACT_TYPES = {"etymology", "idiom", "trivia"}
 
 def _safe_images(word: str) -> List[Dict[str, str]]:
     try:
@@ -24,12 +26,14 @@ def _safe_images(word: str) -> List[Dict[str, str]]:
         logger.warning("image search failed for %r: %s", word, e)
         return []
 
-def _safe_fact(word: str) -> Dict[str, Any]:
+def _safe_fact(payload: Dict[str, Any]) -> Dict[str, Any]:
     try:
-        return get_fact(word)
+        return get_fact(**payload)
     except Exception as e:
-        logger.warning("fact generation failed for %r: %s", word, e)
-        return {"text": "", "type": "trivia", "confidence": 0.0}
+        logger.warning("fact generation failed for %r: %s", payload.get("word"), e)
+        preferred = payload.get("preferred_type")
+        fallback = preferred if preferred in _FACT_TYPES else "trivia"
+        return {"text": "", "type": fallback, "confidence": 0.0}
 
 def _with_timeout(fn, arg, timeout: float):
     """Run fn(arg) with a hard timeout; return None on timeout/error."""
@@ -45,26 +49,88 @@ def _with_timeout(fn, arg, timeout: float):
         logger.warning("task timed out for %r after %.1fs", arg, timeout)
         return None
 
-def enrich_one(word: str) -> Dict[str, Any]:
-    w = (word or "").strip()
+def _normalize_fact_type(value: Optional[str]) -> Optional[str]:
+    if not value:
+        return None
+    lowered = value.strip().lower()
+    return lowered if lowered in _FACT_TYPES else None
+
+
+def enrich_one(
+    entry: Dict[str, Any],
+    *,
+    source_language: Optional[str] = None,
+    target_language: Optional[str] = None,
+) -> Dict[str, Any]:
+    w = (entry.get("word") or "").strip()
     if not w:
         return {}
+    translation = (entry.get("translation") or "").strip()
+    requested_type = _normalize_fact_type(entry.get("fact_type"))
+
     # run images + fact in parallel, each time-boxed
     with ThreadPoolExecutor(max_workers=2) as ex:
         fi = ex.submit(_with_timeout, _safe_images, w, PER_WORD_TIMEOUT)
-        ff = ex.submit(_with_timeout, _safe_fact,   w, PER_WORD_TIMEOUT)
+        ff = ex.submit(
+            _with_timeout,
+            _safe_fact,
+            {
+                "word": w,
+                "translation": translation or None,
+                "source_language": source_language,
+                "target_language": target_language,
+                "preferred_type": requested_type,
+            },
+            PER_WORD_TIMEOUT,
+        )
         images = fi.result() or []
-        fact   = ff.result() or {"text": "", "type": "trivia", "confidence": 0.0}
-    return {"word": w, "images": images, "fact": fact}
+        fact = ff.result() or {
+            "text": "",
+            "type": requested_type or "trivia",
+            "confidence": 0.0,
+        }
+    return {"word": w, "translation": translation, "images": images, "fact": fact}
 
-def get_enrichments(words: List[str]) -> List[Dict[str, Any]]:
-    clean = [w.strip() for w in (words or []) if isinstance(w, str) and w.strip()]
+def get_enrichments(
+    entries: List[Any],
+    *,
+    source_language: Optional[str] = None,
+    target_language: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    clean: List[Dict[str, Any]] = []
+    for item in entries or []:
+        if isinstance(item, dict):
+            word = (item.get("word") or "").strip()
+            if not word:
+                continue
+            translation = (item.get("translation") or "").strip()
+            fact_type = _normalize_fact_type(item.get("fact_type"))
+            clean.append({"word": word, "translation": translation, "fact_type": fact_type})
+        elif isinstance(item, str):
+            word = item.strip()
+            if word:
+                clean.append({"word": word, "translation": "", "fact_type": None})
+
     if not clean:
         return []
     start = time.time()
     results: List[Dict[str, Any]] = []
     with ThreadPoolExecutor(max_workers=min(MAX_THREADS, max(1, len(clean)))) as ex:
-        for row in ex.map(enrich_one, clean):
+        futures = [
+            ex.submit(
+                enrich_one,
+                entry,
+                source_language=source_language,
+                target_language=target_language,
+            )
+            for entry in clean
+        ]
+        for fut in futures:
+            try:
+                row = fut.result()
+            except Exception as exc:
+                logger.warning("enrichment worker failed: %s", exc)
+                continue
             if row:
                 results.append(row)
     logger.info("enrichment built for %d words in %.2fs", len(clean), time.time() - start)

--- a/learning/services/gemini_facts.py
+++ b/learning/services/gemini_facts.py
@@ -6,6 +6,7 @@ import re
 from typing import Any, Dict, Optional, TypedDict
 
 from django.conf import settings
+from django.utils.translation import get_language_info
 
 try:
     import google.generativeai as genai
@@ -22,22 +23,66 @@ class FactResult(TypedDict):
 _VALID_TYPES = {"etymology", "idiom", "trivia"}
 
 # NOTE: double the JSON braces so .format() only substitutes {word}
-_PROMPT_TEMPLATE = """You are a concise linguistics assistant.
+def _language_label(code: Optional[str]) -> str:
+    if not code:
+        return ""
+    try:
+        info = get_language_info(code)
+    except Exception:
+        info = None
+    if not info:
+        return code or ""
+    return info.get("name_local") or info.get("name") or (code or "")
 
-TASK: Generate EXACTLY ONE short, interesting “word fact” for the target word.
 
-CONSTRAINTS:
-- Length <= 220 characters.
-- Choose ONE category: etymology | idiom | trivia (lowercase).
-- Prefer idioms or etymology when reliable; use trivia only if no idiom or origin insight exists.
-- Output MUST be valid JSON (no preamble, no code fences):
-  {{"text":"...", "type":"etymology"}}
+def _build_prompt(
+    word: str,
+    translation: Optional[str],
+    source_language: Optional[str],
+    target_language: Optional[str],
+    preferred_type: Optional[str],
+) -> str:
+    source_label = _language_label(source_language) or (source_language or "the source language")
+    target_label = _language_label(target_language) or (target_language or "the target language")
+    translation_line = (
+        f"- Source language term provided by the teacher: \"{translation}\"."
+        if translation
+        else "- No explicit translation provided; infer a natural bridge to the source language."
+    )
+    bridge_hint = f' such as "{translation}"' if translation else ""
 
-TARGET WORD: "{word}"
+    if preferred_type in _VALID_TYPES:
+        type_instruction = (
+            f"- Focus on a {preferred_type} insight. The JSON \"type\" must be \"{preferred_type}\"."
+        )
+        category_desc = f'"{preferred_type}"'
+        fallback_type = preferred_type
+        example_type = preferred_type
+    else:
+        type_instruction = (
+            "- Choose the strongest category (etymology preferred, otherwise idiom, else trivia) and set the JSON \"type\" accordingly."
+        )
+        category_desc = 'one of "etymology", "idiom", or "trivia"'
+        fallback_type = "trivia"
+        example_type = "etymology"
 
-If you cannot find a reliable fact, reply with:
-{{"text":"", "type":"trivia"}}
-"""
+    prompt = (
+        "You are a concise linguistics assistant.\n\n"
+        "TASK: Generate EXACTLY ONE short, memorable word fact that helps a language teacher connect the student's source language to the new vocabulary word.\n\n"
+        "CONTEXT:\n"
+        f"- Target language: {target_label}.\n"
+        f"- Target word (student is learning): \"{word}\".\n"
+        f"{translation_line}\n"
+        f"- Source language for explanation: {source_label}.\n\n"
+        f"{type_instruction}\n"
+        "REQUIREMENTS:\n"
+        "- Keep the fact <= 220 characters.\n"
+        f"- Make the fact memorable and explicitly link \"{word}\" to the source language{bridge_hint}.\n"
+        "- Use clear, teacher-friendly language.\n"
+        f"- Output MUST be valid JSON with keys \"text\" and \"type\" (no prose or markdown). Example: {{\"text\":\"...\",\"type\":\"{example_type}\"}}. The \"type\" value must be {category_desc}.\n"
+        f"If you cannot find a reliable fact, respond with {{\"text\":\"\", \"type\":\"{fallback_type}\"}}."
+    )
+    return prompt
 
 def _extract_json(payload: str) -> Dict[str, Any]:
     """
@@ -103,13 +148,27 @@ def _coerce_result(obj: Dict[str, Any]) -> FactResult:
     conf = 0.9 if len(text) <= 220 else 0.6
     return {"text": text, "type": ftype, "confidence": conf}
 
-def get_fact(word: str, *, model_id: Optional[str] = None) -> FactResult:
+
+def get_fact(
+    word: str,
+    *,
+    translation: Optional[str] = None,
+    source_language: Optional[str] = None,
+    target_language: Optional[str] = None,
+    preferred_type: Optional[str] = None,
+    model_id: Optional[str] = None,
+) -> FactResult:
     """
-    Generate a single short fact for a word using Gemini.
+    Generate a short fact for a word using Gemini.
     Returns: {"text": str, "type": "etymology"|"idiom"|"trivia", "confidence": float}
     """
     if not word or not isinstance(word, str):
         return {"text": "", "type": "trivia", "confidence": 0.0}
+
+    translation_value = (translation or "").strip()
+    preferred = (preferred_type or "").strip().lower()
+    if preferred not in _VALID_TYPES:
+        preferred = None
 
     if genai is None:
         logger.warning("google-generativeai package not installed.")
@@ -134,7 +193,13 @@ def get_fact(word: str, *, model_id: Optional[str] = None) -> FactResult:
             },
         )
 
-        prompt = _PROMPT_TEMPLATE.format(word=word)
+        prompt = _build_prompt(
+            word,
+            translation_value,
+            source_language,
+            target_language,
+            preferred,
+        )
         resp = model.generate_content(prompt)
 
         raw = getattr(resp, "text", "") or ""
@@ -149,7 +214,10 @@ def get_fact(word: str, *, model_id: Optional[str] = None) -> FactResult:
             return {"text": "", "type": "trivia", "confidence": 0.0}
 
         data = _extract_json(raw)
-        return _coerce_result(data)
+        result = _coerce_result(data)
+        if preferred:
+            result["type"] = preferred
+        return result
 
     except Exception as e:
         logger.exception("Gemini fact generation failed for '%s': %s", word, e)

--- a/learning/templates/learning/add_words_to_list.html
+++ b/learning/templates/learning/add_words_to_list.html
@@ -590,15 +590,25 @@
     }
 
     function parseWords(value) {
-      return value
+      const seen = new Map();
+      value
         .split(/\r?\n/)
         .map(function (line) { return line.trim(); })
         .filter(Boolean)
-        .map(function (line) {
-          const parts = line.split(',');
-          return (parts[0] || '').trim();
-        })
-        .filter(Boolean);
+        .forEach(function (line) {
+          const parts = line.split(',', 2);
+          const word = (parts[0] || '').trim();
+          const translation = (parts[1] || '').trim();
+          if (!word) {
+            return;
+          }
+          if (!seen.has(word)) {
+            seen.set(word, { word: word, translation: translation });
+          } else if (translation && !seen.get(word).translation) {
+            seen.get(word).translation = translation;
+          }
+        });
+      return Array.from(seen.values());
     }
 
     previewButton.addEventListener('click', function () {
@@ -606,9 +616,8 @@
       if (!textarea) {
         return;
       }
-      const parsed = parseWords(textarea.value);
-      const uniqueWords = Array.from(new Set(parsed));
-      if (uniqueWords.length === 0) {
+      const entries = parseWords(textarea.value);
+      if (entries.length === 0) {
         alert('Please add at least one word before previewing.');
         return;
       }
@@ -625,7 +634,7 @@
         root = ReactDOM.createRoot(rootContainer);
         root.render(
           React.createElement(Component, {
-            words: uniqueWords,
+            entries: entries,
             listId: listId,
             onClose: hideModal,
             fetchImpl: fetchWrapper,

--- a/learning/tests/test_enrichment_api.py
+++ b/learning/tests/test_enrichment_api.py
@@ -22,9 +22,16 @@ class EnrichmentAPITests(TestCase):
         self.client.force_authenticate(user=self.teacher)
 
     def test_preview_returns_enrichment_payload(self) -> None:
+        vocab_list = VocabularyList.objects.create(
+            name="Test List",
+            source_language="en",
+            target_language="de",
+            teacher=self.teacher,
+        )
         payload = [
             {
                 "word": "apple",
+                "translation": "Apfel",
                 "images": [
                     {
                         "url": "https://example.com/apple.jpg",
@@ -40,13 +47,24 @@ class EnrichmentAPITests(TestCase):
         with mock.patch("learning.api.enrichment.get_enrichments", return_value=payload) as mocked:
             resp = self.client.post(
                 "/api/vocab/enrichment/preview",
-                {"words": ["apple"]},
+                {
+                    "list_id": vocab_list.id,
+                    "entries": [
+                        {"word": "apple", "translation": "Apfel"},
+                    ],
+                },
                 format="json",
             )
         self.assertEqual(resp.status_code, 200)
         data = resp.json()
         self.assertEqual(data, payload)
-        mocked.assert_called_once_with(["apple"])
+        mocked.assert_called_once()
+        args, kwargs = mocked.call_args
+        self.assertEqual(args[0], [{"word": "apple", "translation": "Apfel"}])
+        self.assertEqual(
+            kwargs,
+            {"source_language": "en", "target_language": "de"},
+        )
 
     def test_confirm_updates_vocabulary_word(self) -> None:
         vocab_list = VocabularyList.objects.create(

--- a/static/js/bulk_enrichment_preview.jsx
+++ b/static/js/bulk_enrichment_preview.jsx
@@ -12,7 +12,7 @@ function toPlainText(value) {
   return value.replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim();
 }
 
-function BulkAddEnrichmentPreview({ words, listId, onClose, fetchImpl }) {
+function BulkAddEnrichmentPreview({ entries, listId, onClose, fetchImpl }) {
   const fetchFn = fetchImpl || fetch;
   const [rows, setRows] = useState([]);
   const [selectedImage, setSelectedImage] = useState({});
@@ -23,54 +23,85 @@ function BulkAddEnrichmentPreview({ words, listId, onClose, fetchImpl }) {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState(null);
   const [refreshingWord, setRefreshingWord] = useState(null);
+  const [factCache, setFactCache] = useState({});
 
-  const fetchPreviewFor = useCallback(async (targetWords) => {
-    if (!targetWords || !targetWords.length) {
-      return [];
-    }
+  const fetchPreviewFor = useCallback(
+    async (targetEntries) => {
+      const payloadEntries = (targetEntries || [])
+        .map((item) => {
+          if (!item) {
+            return null;
+          }
+          const word = (item.word || "").trim();
+          if (!word) {
+            return null;
+          }
+          const translation = (item.translation || "").trim();
+          const factType = item.factType;
+          const validType = factType && ["etymology", "idiom", "trivia"].includes(factType) ? factType : undefined;
+          return { word, translation, fact_type: validType };
+        })
+        .filter(Boolean);
 
-    const headers = { "Content-Type": "application/json" };
-    const csrfToken = getCookie("csrftoken");
-    if (csrfToken) {
-      headers["X-CSRFToken"] = csrfToken;
-    }
-
-    const response = await fetchFn("/api/vocab/enrichment/preview", {
-      method: "POST",
-      headers,
-      credentials: "include",
-      body: JSON.stringify({ words: targetWords }),
-    });
-
-    let data = null;
-    try {
-      data = await response.json();
-    } catch (err) {
-      if (!response.ok) {
-        throw new Error("Failed to load preview");
+      if (!payloadEntries.length) {
+        return [];
       }
-      throw err;
-    }
 
-    if (!response.ok) {
-      const detail = data && typeof data === "object" && data.detail ? data.detail : null;
-      throw new Error(detail || "Failed to load preview");
-    }
+      const headers = { "Content-Type": "application/json" };
+      const csrfToken = getCookie("csrftoken");
+      if (csrfToken) {
+        headers["X-CSRFToken"] = csrfToken;
+      }
 
-    if (!Array.isArray(data)) {
-      throw new Error("Unexpected response from server");
-    }
+      const response = await fetchFn("/api/vocab/enrichment/preview", {
+        method: "POST",
+        headers,
+        credentials: "include",
+        body: JSON.stringify({
+          list_id: listId,
+          entries: payloadEntries,
+        }),
+      });
 
-    return data;
-  }, [fetchFn]);
+      let data = null;
+      try {
+        data = await response.json();
+      } catch (err) {
+        if (!response.ok) {
+          throw new Error("Failed to load preview");
+        }
+        throw err;
+      }
+
+      if (!response.ok) {
+        const detail = data && typeof data === "object" && data.detail ? data.detail : null;
+        throw new Error(detail || "Failed to load preview");
+      }
+
+      if (!Array.isArray(data)) {
+        throw new Error("Unexpected response from server");
+      }
+
+      return data;
+    },
+    [fetchFn, listId]
+  );
 
   const applyInitialRows = useCallback((rowsData) => {
     const initSel = {};
     const initFact = {};
+    const initCache = {};
 
     rowsData.forEach((item) => {
       initSel[item.word] = (item.images && item.images[0]) || null;
       initFact[item.word] = Object.assign({}, item.fact || {});
+      if (item.fact && item.fact.type) {
+        initCache[item.word] = {
+          [item.fact.type]: Object.assign({}, item.fact),
+        };
+      } else {
+        initCache[item.word] = {};
+      }
     });
 
     setRows(rowsData);
@@ -78,6 +109,7 @@ function BulkAddEnrichmentPreview({ words, listId, onClose, fetchImpl }) {
     setFactEdits(initFact);
     setApproveImage({});
     setApproveFact({});
+    setFactCache(initCache);
   }, []);
 
   const replaceRow = useCallback((word, updatedRow) => {
@@ -107,6 +139,15 @@ function BulkAddEnrichmentPreview({ words, listId, onClose, fetchImpl }) {
     setFactEdits((prev) => Object.assign({}, prev, { [cleanedWord]: Object.assign({}, nextRow.fact || {}) }));
     setApproveImage((prev) => Object.assign({}, prev, { [cleanedWord]: false }));
     setApproveFact((prev) => Object.assign({}, prev, { [cleanedWord]: false }));
+    setFactCache((prev) => {
+      const next = Object.assign({}, prev);
+      const existing = Object.assign({}, next[cleanedWord] || {});
+      if (nextRow.fact && nextRow.fact.type) {
+        existing[nextRow.fact.type] = Object.assign({}, nextRow.fact);
+      }
+      next[cleanedWord] = existing;
+      return next;
+    });
   }, []);
 
   useEffect(() => {
@@ -116,7 +157,7 @@ function BulkAddEnrichmentPreview({ words, listId, onClose, fetchImpl }) {
       try {
         setError(null);
         setLoading(true);
-        const rowsData = await fetchPreviewFor(words);
+        const rowsData = await fetchPreviewFor(entries || []);
         if (!active) {
           return;
         }
@@ -130,6 +171,7 @@ function BulkAddEnrichmentPreview({ words, listId, onClose, fetchImpl }) {
         setFactEdits({});
         setApproveImage({});
         setApproveFact({});
+        setFactCache({});
         setError(err && err.message ? err.message : "Failed to load preview");
       } finally {
         if (active) {
@@ -141,54 +183,95 @@ function BulkAddEnrichmentPreview({ words, listId, onClose, fetchImpl }) {
     return () => {
       active = false;
     };
-  }, [words, fetchPreviewFor, applyInitialRows]);
+  }, [entries, fetchPreviewFor, applyInitialRows]);
 
-  const refreshWord = async (word) => {
-    if (!word) {
-      return;
-    }
-
-    try {
-      setError(null);
-      setRefreshingWord(word);
-      const rowsData = await fetchPreviewFor([word]);
-      const normalized = word.trim().toLowerCase();
-      const updatedRow = rowsData.find((item) => (item.word || "").trim().toLowerCase() === normalized) || rowsData[0] || null;
-      if (!updatedRow) {
-        throw new Error("No enrichment suggestions returned.");
+  const refreshWord = useCallback(
+    async (word, factType) => {
+      if (!word) {
+        return;
       }
-      replaceRow(word, updatedRow);
-    } catch (err) {
-      setError(err && err.message ? err.message : "Failed to refresh suggestions");
-    } finally {
-      setRefreshingWord(null);
-    }
-  };
 
-  const reloadAll = async () => {
-    if (!words || !words.length) {
+      const currentRows = rows || [];
+      const existingRow = currentRows.find((item) => item.word === word);
+      const fallbackEntry = (entries || []).find((item) => item.word === word);
+      const translation = (existingRow && existingRow.translation) || (fallbackEntry && fallbackEntry.translation) || "";
+
+      try {
+        setError(null);
+        setRefreshingWord(word);
+        const rowsData = await fetchPreviewFor([
+          { word, translation, factType },
+        ]);
+        const normalized = word.trim().toLowerCase();
+        const updatedRow =
+          rowsData.find((item) => (item.word || "").trim().toLowerCase() === normalized) || rowsData[0] || null;
+        if (!updatedRow) {
+          throw new Error("No enrichment suggestions returned.");
+        }
+        const patchedRow = Object.assign({}, updatedRow, {
+          translation: updatedRow.translation || translation,
+        });
+        replaceRow(word, patchedRow);
+      } catch (err) {
+        setError(err && err.message ? err.message : "Failed to refresh suggestions");
+      } finally {
+        setRefreshingWord(null);
+      }
+    },
+    [entries, fetchPreviewFor, replaceRow, rows]
+  );
+
+  const reloadAll = useCallback(async () => {
+    const currentRows = rows || [];
+    const baseEntries = currentRows.length
+      ? currentRows.map((row) => ({
+          word: row.word,
+          translation:
+            row.translation || ((entries || []).find((item) => item.word === row.word)?.translation || ""),
+          factType: (factEdits[row.word] && factEdits[row.word].type) || (row.fact && row.fact.type),
+        }))
+      : (entries || []);
+
+    if (!baseEntries.length) {
       return;
     }
 
     try {
       setError(null);
       setLoading(true);
-      const rowsData = await fetchPreviewFor(words);
+      const rowsData = await fetchPreviewFor(baseEntries);
       applyInitialRows(rowsData);
     } catch (err) {
       setError(err && err.message ? err.message : "Failed to refresh suggestions");
     } finally {
       setLoading(false);
     }
-  };
+  }, [applyInitialRows, entries, factEdits, fetchPreviewFor, rows]);
 
   const resetFactToSuggestion = (word) => {
-    const row = rows.find((item) => item.word === word);
+    const row = (rows || []).find((item) => item.word === word);
     if (!row) {
       return;
     }
-    setFactEdits((prev) => Object.assign({}, prev, { [word]: Object.assign({}, row.fact || {}) }));
+    const currentType = (factEdits[word] && factEdits[word].type) || (row.fact && row.fact.type) || "trivia";
+    const cached = factCache[word] && factCache[word][currentType];
     setApproveFact((prev) => Object.assign({}, prev, { [word]: false }));
+    if (cached) {
+      setFactEdits((prev) => Object.assign({}, prev, { [word]: Object.assign({}, cached) }));
+      return;
+    }
+    setFactEdits((prev) => {
+      const next = Object.assign({}, prev);
+      const existing = Object.assign({}, prev[word] || {});
+      existing.type = currentType;
+      existing.text = "";
+      if (typeof existing.confidence !== "number") {
+        existing.confidence = row.fact && row.fact.confidence;
+      }
+      next[word] = existing;
+      return next;
+    });
+    refreshWord(word, currentType);
   };
 
   const clearImageSelection = (word) => {
@@ -196,20 +279,46 @@ function BulkAddEnrichmentPreview({ words, listId, onClose, fetchImpl }) {
     setApproveImage((prev) => Object.assign({}, prev, { [word]: false }));
   };
 
+  const handleFactTypeChange = useCallback(
+    (word, nextType) => {
+      if (!word || !nextType) {
+        return;
+      }
+      const baseRow = (rows || []).find((item) => item.word === word);
+      setFactEdits((prev) => {
+        const next = Object.assign({}, prev);
+        const current = Object.assign({}, prev[word] || {});
+        current.type = nextType;
+        current.text = "";
+        if (typeof current.confidence !== "number") {
+          current.confidence = baseRow && baseRow.fact ? baseRow.fact.confidence : current.confidence;
+        }
+        next[word] = current;
+        return next;
+      });
+      setApproveFact((prev) => Object.assign({}, prev, { [word]: false }));
+      const cached = factCache[word] && factCache[word][nextType];
+      if (cached) {
+        setFactEdits((prev) => Object.assign({}, prev, { [word]: Object.assign({}, cached) }));
+        return;
+      }
+      refreshWord(word, nextType);
+    },
+    [factCache, refreshWord, rows]
+  );
+
   const onConfirm = async () => {
     try {
       setSaving(true);
       setError(null);
-      const items = rows.map((r) => {
-        const image = selectedImage[r.word];
-        const fact = factEdits[r.word];
-        const factText = (fact && fact.text) || "";
+      const items = (rows || []).map((r) => {
+        const fact = factEdits[r.word] || {};
         return {
           word: r.word,
-          image,
+          image: selectedImage[r.word],
           fact,
-          approveImage: Boolean(approveImage[r.word] && image),
-          approveFact: Boolean(approveFact[r.word] && factText.trim()),
+          approveImage: Boolean(approveImage[r.word] && selectedImage[r.word]),
+          approveFact: Boolean(approveFact[r.word] && (fact.text || "").trim()),
         };
       });
       const headers = { "Content-Type": "application/json" };
@@ -274,7 +383,7 @@ function BulkAddEnrichmentPreview({ words, listId, onClose, fetchImpl }) {
       {rows.length === 0 ? (
         <div className="enrichment-empty-state">No enrichment suggestions were generated for these words.</div>
       ) : (
-        rows.map((row) => {
+        rows.map(row => {
           const currentImage = selectedImage[row.word] || null;
           const factState = factEdits[row.word] || {};
           const factValue = factState.text || "";
@@ -282,9 +391,7 @@ function BulkAddEnrichmentPreview({ words, listId, onClose, fetchImpl }) {
           const factConfidence =
             typeof factState.confidence === "number"
               ? factState.confidence
-              : row.fact && typeof row.fact.confidence === "number"
-              ? row.fact.confidence
-              : null;
+              : row.fact && row.fact.confidence;
           const confidenceLabel =
             typeof factConfidence === "number" && !Number.isNaN(factConfidence)
               ? `${Math.round(Math.max(0, Math.min(1, factConfidence)) * 100)}% confidence`
@@ -295,12 +402,15 @@ function BulkAddEnrichmentPreview({ words, listId, onClose, fetchImpl }) {
           return (
             <section key={row.word} className="enrichment-card">
               <div className="enrichment-card-header">
-                <h3 className="enrichment-card-title">{row.word}</h3>
+                <h3 className="enrichment-card-title">
+                  {row.word}
+                  {row.translation ? ` (${row.translation})` : ""}
+                </h3>
                 <div className="enrichment-card-actions">
                   <button
                     type="button"
                     className="enrichment-button enrichment-button--ghost"
-                    onClick={() => refreshWord(row.word)}
+                    onClick={() => refreshWord(row.word, factType)}
                     disabled={isRefreshing || disableGlobalActions}
                   >
                     {isRefreshing ? "Refreshing…" : "New suggestions"}
@@ -336,16 +446,14 @@ function BulkAddEnrichmentPreview({ words, listId, onClose, fetchImpl }) {
 
                   {row.images && row.images.length > 0 && (
                     <div className="enrichment-thumb-list">
-                      {row.images.map((img) => {
+                      {row.images.map(img => {
                         const selected = currentImage && currentImage.url === img.url;
                         return (
                           <button
                             type="button"
                             key={img.url}
                             className={`enrichment-thumb${selected ? " is-selected" : ""}`}
-                            onClick={() =>
-                              setSelectedImage((prev) => Object.assign({}, prev, { [row.word]: img }))
-                            }
+                            onClick={() => setSelectedImage(prev => Object.assign({}, prev, { [row.word]: img }))}
                             title={toPlainText(img.attribution)}
                           >
                             <img src={img.thumb || img.url} alt={row.word} />
@@ -360,11 +468,7 @@ function BulkAddEnrichmentPreview({ words, listId, onClose, fetchImpl }) {
                       <input
                         type="checkbox"
                         checked={Boolean(approveImage[row.word]) && Boolean(currentImage)}
-                        onChange={(event) =>
-                          setApproveImage((prev) =>
-                            Object.assign({}, prev, { [row.word]: event.target.checked })
-                          )
-                        }
+                        onChange={e => setApproveImage(prev => Object.assign({}, prev, { [row.word]: e.target.checked }))}
                         disabled={!currentImage}
                       />
                       Approve selected image
@@ -392,29 +496,23 @@ function BulkAddEnrichmentPreview({ words, listId, onClose, fetchImpl }) {
                     className="enrichment-fact-text"
                     maxLength={220}
                     value={factValue}
-                    onChange={(event) =>
-                      setFactEdits((prev) => {
-                        const next = Object.assign({}, prev[row.word] || {});
-                        next.text = event.target.value;
-                        next.type = factType;
-                        next.confidence = factConfidence;
-                        return Object.assign({}, prev, { [row.word]: next });
-                      })
+                    onChange={e =>
+                      setFactEdits(prev => Object.assign({}, prev, {
+                        [row.word]: Object.assign({}, prev[row.word] || { type: factType }, {
+                          text: e.target.value,
+                          type: factType,
+                          confidence: factConfidence,
+                        }),
+                      }))
                     }
+                    disabled={isRefreshing}
                   />
                   <div className="enrichment-fact-footer">
                     <span>{factValue.length}/220 characters</span>
                     <select
                       value={factType}
-                      onChange={(event) =>
-                        setFactEdits((prev) => {
-                          const next = Object.assign({}, prev[row.word] || {});
-                          next.type = event.target.value;
-                          next.text = factValue;
-                          next.confidence = factConfidence;
-                          return Object.assign({}, prev, { [row.word]: next });
-                        })
-                      }
+                      onChange={e => handleFactTypeChange(row.word, e.target.value)}
+                      disabled={isRefreshing || disableGlobalActions}
                     >
                       <option value="etymology">etymology</option>
                       <option value="idiom">idiom</option>
@@ -425,11 +523,7 @@ function BulkAddEnrichmentPreview({ words, listId, onClose, fetchImpl }) {
                     <input
                       type="checkbox"
                       checked={Boolean(approveFact[row.word]) && canApproveFact}
-                      onChange={(event) =>
-                        setApproveFact((prev) =>
-                          Object.assign({}, prev, { [row.word]: event.target.checked })
-                        )
-                      }
+                      onChange={e => setApproveFact(prev => Object.assign({}, prev, { [row.word]: e.target.checked }))}
                       disabled={!canApproveFact}
                     />
                     Approve fact
@@ -450,12 +544,7 @@ function BulkAddEnrichmentPreview({ words, listId, onClose, fetchImpl }) {
         >
           {saving ? "Saving…" : "Confirm & Add to List"}
         </button>
-        <button
-          type="button"
-          onClick={onClose}
-          className="enrichment-button enrichment-button--ghost"
-          disabled={saving}
-        >
+        <button type="button" onClick={onClose} className="enrichment-button enrichment-button--ghost" disabled={saving}>
           Cancel
         </button>
       </div>


### PR DESCRIPTION
## Summary
- update the enrichment preview API to accept structured word entries and to look up the list languages for fact generation
- enhance the enrichment service and Gemini prompt to include translation context and support preferred fact types when fetching suggestions
- refresh the React/Babel enrichment preview UI to send translations, cache facts per type, and refetch text whenever the teacher switches categories

## Testing
- python manage.py test learning.tests.test_enrichment_api

------
https://chatgpt.com/codex/tasks/task_e_68c8ed9a7aa4832592407c59840d465d