### PR TITLE
Improve enrichment suggestions and fallbacks

### DIFF
--- a/learning/api/enrichment.py
+++ b/learning/api/enrichment.py
@@ -14,6 +14,12 @@ class PreviewEntrySerializer(serializers.Serializer):
     word = serializers.CharField(allow_blank=False, trim_whitespace=True, max_length=100)
     translation = serializers.CharField(required=False, allow_blank=True, trim_whitespace=True, max_length=100)
     fact_type = serializers.ChoiceField(choices=("etymology", "idiom", "trivia"), required=False)
+    exclude_images = serializers.ListField(
+        child=serializers.URLField(),
+        required=False,
+        allow_empty=True,
+        max_length=50,
+    )
 
 
 class PreviewRequestSerializer(serializers.Serializer):

--- a/learning/tests/test_enrichment_service.py
+++ b/learning/tests/test_enrichment_service.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from unittest import mock
+
+from django.test import SimpleTestCase
+
+from learning.services import enrichment
+
+
+class EnrichmentServiceTests(SimpleTestCase):
+    @mock.patch("learning.services.enrichment.search_images", return_value=[])
+    @mock.patch(
+        "learning.services.enrichment.get_fact",
+        return_value={"text": "", "type": "trivia", "confidence": 0.4},
+    )
+    def test_enrich_one_uses_fallback_fact_when_empty(
+        self,
+        mock_get_fact: mock.Mock,
+        mock_search_images: mock.Mock,
+    ) -> None:
+        result = enrichment.enrich_one(
+            {"word": "avion", "translation": "plane"},
+            source_language="en",
+            target_language="fr",
+        )
+
+        self.assertEqual(result["word"], "avion")
+        self.assertEqual(result["translation"], "plane")
+        self.assertIn("avion", result["fact"]["text"])
+        self.assertIn("plane", result["fact"]["text"])
+        self.assertEqual(result["fact"]["type"], "trivia")
+        self.assertGreaterEqual(result["fact"]["confidence"], 0)
+
+        mock_get_fact.assert_called_once()
+        called_kwargs = mock_get_fact.call_args.kwargs
+        self.assertEqual(called_kwargs.get("word"), "avion")
+        self.assertEqual(called_kwargs.get("translation"), "plane")
+
+        mock_search_images.assert_called_once()
+        args, kwargs = mock_search_images.call_args
+        self.assertEqual(args[0], "plane")
+        self.assertEqual(kwargs.get("exclude_urls"), [])

--- a/learning/tests/test_wikimedia_images.py
+++ b/learning/tests/test_wikimedia_images.py
@@ -21,7 +21,7 @@ class FakeResponse:
 
 
 class WikimediaImageSearchTests(SimpleTestCase):
-    @mock.patch("learning.services.wikimedia_images.requests.get")
+    @mock.patch("learning.services.wikimedia_images.SESSION.get")
     def test_primary_query_returns_images(self, mock_get: mock.Mock) -> None:
         mock_get.return_value = FakeResponse(
             {
@@ -53,13 +53,14 @@ class WikimediaImageSearchTests(SimpleTestCase):
                     "thumb": "https://example.com/dog-thumb.jpg",
                     "source": "Wikimedia",
                     "attribution": "Photographer",
+                    "attribution_text": "Photographer",
                     "license": "CC-BY",
                 }
             ],
         )
         mock_get.assert_called_once()
 
-    @mock.patch("learning.services.wikimedia_images.requests.get")
+    @mock.patch("learning.services.wikimedia_images.SESSION.get")
     def test_fallback_query_uses_search_titles(self, mock_get: mock.Mock) -> None:
         mock_get.side_effect = [
             FakeResponse({"query": {"pages": {}}}),
@@ -94,12 +95,63 @@ class WikimediaImageSearchTests(SimpleTestCase):
                     "thumb": "https://example.com/dog-2.jpg",
                     "source": "Wikimedia",
                     "attribution": "Wikimedia",
+                    "attribution_text": "Wikimedia",
                     "license": "CC0",
                 }
             ],
         )
         self.assertEqual(mock_get.call_count, 3)
 
-    @mock.patch("learning.services.wikimedia_images.requests.get", side_effect=Exception("boom"))
+    @mock.patch("learning.services.wikimedia_images.SESSION.get")
+    def test_exclude_urls_filters_previous_results(self, mock_get: mock.Mock) -> None:
+        mock_get.return_value = FakeResponse(
+            {
+                "query": {
+                    "pages": {
+                        "1": {
+                            "imageinfo": [
+                                {
+                                    "url": "https://example.com/dog-old.jpg",
+                                    "thumburl": "https://example.com/dog-old-thumb.jpg",
+                                    "extmetadata": {"Artist": {"value": "Old"}},
+                                }
+                            ]
+                        },
+                        "2": {
+                            "imageinfo": [
+                                {
+                                    "url": "https://example.com/dog-new.jpg",
+                                    "thumburl": "https://example.com/dog-new-thumb.jpg",
+                                    "extmetadata": {"Artist": {"value": "New"}},
+                                }
+                            ]
+                        },
+                    }
+                }
+            }
+        )
+
+        results = wikimedia_images.search_images(
+            "dog",
+            limit=2,
+            exclude_urls=["https://example.com/dog-old.jpg"],
+        )
+
+        self.assertEqual(
+            results,
+            [
+                {
+                    "url": "https://example.com/dog-new.jpg",
+                    "thumb": "https://example.com/dog-new-thumb.jpg",
+                    "source": "Wikimedia",
+                    "attribution": "New",
+                    "attribution_text": "New",
+                    "license": "",
+                }
+            ],
+        )
+        self.assertEqual(mock_get.call_count, 1)
+
+    @mock.patch("learning.services.wikimedia_images.SESSION.get", side_effect=Exception("boom"))
     def test_request_error_returns_empty_list(self, mock_get: mock.Mock) -> None:  # noqa: ARG002
         self.assertEqual(wikimedia_images.search_images("cat"), [])


### PR DESCRIPTION
## Summary
- ensure enrichment preview serializes exclude image lists and passes translations correctly for fact generation
- harden enrichment services with deterministic trivia fallback text and improved image search filtering/exclusion logic
- update bulk enrichment UI with separate image/fact refresh actions, reset button, and exclusion-aware requests
- expand automated coverage for enrichment services and Wikimedia image helper

## Testing
- python manage.py test learning.tests

------
https://chatgpt.com/codex/tasks/task_e_68c93d65e53483258bde173cc1e936e8