### PR TITLE
Improve enrichment refresh handling and image queries

### DIFF
--- a/frontend/src/components/BulkAddEnrichmentPreview.tsx
+++ b/frontend/src/components/BulkAddEnrichmentPreview.tsx
@@ -12,6 +12,15 @@ function toPlainText(value?: string | null): string {
   return value.replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim();
 }
 
+function extractImageUrls(list?: ImageCandidate[] | null): string[] {
+  if (!Array.isArray(list)) {
+    return [];
+  }
+  return list
+    .map(img => (img?.url || "").toString().trim())
+    .filter((url): url is string => Boolean(url));
+}
+
 type ImageCandidate = {
   url: string;
   thumb?: string;
@@ -37,9 +46,16 @@ type WordEntry = {
   word: string;
   translation?: string;
   factType?: Fact["type"];
+  excludeImages?: string[];
 };
 
 type FactCache = Record<string, Partial<Record<Fact["type"], Fact>>>;
+
+type RefreshOptions = {
+  refreshImages?: boolean;
+  refreshFact?: boolean;
+  factType?: Fact["type"];
+};
 
 type Props = {
   entries: WordEntry[];
@@ -63,7 +79,9 @@ export default function BulkAddEnrichmentPreview({
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [refreshingWord, setRefreshingWord] = useState<string | null>(null);
+  const [refreshingKind, setRefreshingKind] = useState<"images" | "fact" | "both" | null>(null);
   const [factCache, setFactCache] = useState<FactCache>({});
+  const [imageHistory, setImageHistory] = useState<Record<string, string[]>>({});
 
   const approveAllSelectedImages = useCallback(() => {
     setApproveImage(prev => {
@@ -101,13 +119,26 @@ export default function BulkAddEnrichmentPreview({
           }
           const translation = (item.translation || "").trim();
           const factType = item.factType;
+          const excludeImages = (item.excludeImages || [])
+            .map(url => (url || "").toString().trim())
+            .filter(url => Boolean(url));
           return {
             word,
             translation,
             fact_type: factType && ["etymology", "idiom", "trivia"].includes(factType) ? factType : undefined,
+            exclude_images: excludeImages.length ? excludeImages : undefined,
           };
         })
-        .filter((entry): entry is { word: string; translation: string; fact_type?: Fact["type"] } => Boolean(entry));
+        .filter(
+          (
+            entry,
+          ): entry is {
+            word: string;
+            translation: string;
+            fact_type?: Fact["type"];
+            exclude_images?: string[];
+          } => Boolean(entry)
+        );
 
       if (!payloadEntries.length) {
         return [];
@@ -158,9 +189,11 @@ export default function BulkAddEnrichmentPreview({
     const initSel: Record<string, ImageCandidate | null> = {};
     const initFact: Record<string, Fact> = {};
     const initCache: FactCache = {};
+    const initHistory: Record<string, string[]> = {};
 
     rowsData.forEach(item => {
-      initSel[item.word] = item.images[0] || null;
+      const images = Array.isArray(item.images) ? item.images : [];
+      initSel[item.word] = images[0] || null;
       initFact[item.word] = { ...item.fact };
       if (item.fact?.type) {
         initCache[item.word] = {
@@ -169,6 +202,7 @@ export default function BulkAddEnrichmentPreview({
       } else {
         initCache[item.word] = {};
       }
+      initHistory[item.word] = Array.from(new Set(extractImageUrls(images)));
     });
 
     setRows(rowsData);
@@ -177,45 +211,7 @@ export default function BulkAddEnrichmentPreview({
     setApproveImage({});
     setApproveFact({});
     setFactCache(initCache);
-  }, []);
-
-  const replaceRow = useCallback((word: string, updatedRow: Row) => {
-    const cleanedWord = word.trim();
-    const nextRow: Row = {
-      ...updatedRow,
-      word: cleanedWord,
-      images: Array.isArray(updatedRow.images) ? updatedRow.images : [],
-    };
-    const candidates = nextRow.images;
-
-    setRows(prev => {
-      const exists = prev.some(r => r.word === cleanedWord);
-      if (!exists) {
-        return [...prev, nextRow];
-      }
-      return prev.map(r => (r.word === cleanedWord ? nextRow : r));
-    });
-
-    setSelectedImage(prev => {
-      const next = { ...prev };
-      const previousChoice = prev[cleanedWord];
-      const match = candidates.find(img => previousChoice && previousChoice.url === img.url) || candidates[0] || null;
-      next[cleanedWord] = match;
-      return next;
-    });
-
-    setFactEdits(prev => ({ ...prev, [cleanedWord]: { ...nextRow.fact } }));
-    setApproveImage(prev => ({ ...prev, [cleanedWord]: false }));
-    setApproveFact(prev => ({ ...prev, [cleanedWord]: false }));
-    setFactCache(prev => {
-      const next = { ...prev };
-      const existing = { ...(next[cleanedWord] || {}) };
-      if (nextRow.fact?.type) {
-        existing[nextRow.fact.type] = { ...nextRow.fact };
-      }
-      next[cleanedWord] = existing;
-      return next;
-    });
+    setImageHistory(initHistory);
   }, []);
 
   useEffect(() => {
@@ -240,6 +236,7 @@ export default function BulkAddEnrichmentPreview({
         setApproveImage({});
         setApproveFact({});
         setFactCache({});
+        setImageHistory({});
         setError(err?.message || "Failed to load preview");
       } finally {
         if (active) {
@@ -254,7 +251,8 @@ export default function BulkAddEnrichmentPreview({
   }, [entries, fetchPreviewFor, applyInitialRows]);
 
   const refreshWord = useCallback(
-    async (word: string, factType?: Fact["type"]) => {
+    async (word: string, options: RefreshOptions = {}) => {
+      const { refreshImages = true, refreshFact = true, factType } = options;
       if (!word) {
         return;
       }
@@ -262,13 +260,24 @@ export default function BulkAddEnrichmentPreview({
       const existingRow = rows.find(item => item.word === word);
       const fallbackEntry = entries.find(item => item.word === word);
       const translation = existingRow?.translation || fallbackEntry?.translation || "";
+      const cleanedWord = word.trim();
+      const effectiveFactType = (factType || factEdits[word]?.type || existingRow?.fact.type || "trivia") as Fact["type"];
+      const knownExclusions = imageHistory[word] || [];
+      const excludeImages = refreshImages
+        ? Array.from(new Set([...knownExclusions, ...extractImageUrls(existingRow?.images)]))
+        : [];
 
       try {
         setError(null);
         setRefreshingWord(word);
-        const rowsData = await fetchPreviewFor([
-          { word, translation, factType },
-        ]);
+        setRefreshingKind(refreshImages && refreshFact ? "both" : refreshImages ? "images" : "fact");
+        const requestEntry: WordEntry = {
+          word,
+          translation,
+          factType: refreshFact ? effectiveFactType : undefined,
+          excludeImages: refreshImages ? excludeImages : undefined,
+        };
+        const rowsData = await fetchPreviewFor([requestEntry]);
         const normalized = word.trim().toLowerCase();
         const updatedRow =
           rowsData.find(item => item.word.trim().toLowerCase() === normalized) || rowsData[0] || null;
@@ -279,14 +288,79 @@ export default function BulkAddEnrichmentPreview({
           ...updatedRow,
           translation: updatedRow.translation || translation,
         };
-        replaceRow(word, patchedRow);
+
+        const patchedImages = Array.isArray(patchedRow.images) ? patchedRow.images : [];
+        const existingImages = Array.isArray(existingRow?.images) ? existingRow?.images ?? [] : [];
+        const nextImages = refreshImages ? patchedImages : existingImages.length ? existingImages : patchedImages;
+        const nextFact = refreshFact ? patchedRow.fact : existingRow?.fact || patchedRow.fact;
+        const resolvedFact: Fact = {
+          text: (nextFact?.text || "").trim(),
+          type: (nextFact?.type || effectiveFactType) as Fact["type"],
+          confidence:
+            typeof nextFact?.confidence === "number"
+              ? nextFact.confidence
+              : typeof existingRow?.fact?.confidence === "number"
+              ? existingRow.fact.confidence
+              : typeof patchedRow.fact?.confidence === "number"
+              ? patchedRow.fact.confidence
+              : 0,
+        };
+        const nextRow: Row = {
+          word: cleanedWord,
+          translation: patchedRow.translation || "",
+          images: nextImages,
+          fact: resolvedFact,
+        };
+
+        setRows(prev => {
+          const exists = prev.some(r => r.word === cleanedWord);
+          if (!exists) {
+            return [...prev, nextRow];
+          }
+          return prev.map(r => (r.word === cleanedWord ? nextRow : r));
+        });
+
+        if (refreshImages) {
+          const candidates = Array.isArray(nextImages) ? nextImages : [];
+          setSelectedImage(prev => ({
+            ...prev,
+            [cleanedWord]: candidates[0] || null,
+          }));
+          setApproveImage(prev => ({ ...prev, [cleanedWord]: false }));
+          setImageHistory(prev => {
+            const next = { ...prev };
+            const existing = Array.isArray(prev[cleanedWord]) ? prev[cleanedWord] : [];
+            const merged = Array.from(new Set([...existing, ...excludeImages, ...extractImageUrls(candidates)]));
+            next[cleanedWord] = merged;
+            return next;
+          });
+        }
+
+        if (refreshFact) {
+          const baseFact: Fact = { ...resolvedFact };
+          setFactEdits(prev => ({
+            ...prev,
+            [cleanedWord]: { ...baseFact },
+          }));
+          setApproveFact(prev => ({ ...prev, [cleanedWord]: false }));
+          setFactCache(prev => {
+            const next = { ...prev };
+            const existingCache = { ...(next[cleanedWord] || {}) };
+            if (baseFact?.type) {
+              existingCache[baseFact.type] = { ...baseFact };
+            }
+            next[cleanedWord] = existingCache;
+            return next;
+          });
+        }
       } catch (err: any) {
         setError(err?.message || "Failed to refresh suggestions");
       } finally {
         setRefreshingWord(null);
+        setRefreshingKind(null);
       }
     },
-    [entries, fetchPreviewFor, replaceRow, rows]
+    [entries, factEdits, fetchPreviewFor, imageHistory, rows]
   );
 
   const reloadAll = useCallback(async () => {
@@ -335,7 +409,7 @@ export default function BulkAddEnrichmentPreview({
         confidence: prev[word]?.confidence ?? row.fact.confidence,
       },
     }));
-    void refreshWord(word, currentType);
+    void refreshWord(word, { refreshImages: false, refreshFact: true, factType: currentType });
   };
 
   const clearImageSelection = (word: string) => {
@@ -364,7 +438,7 @@ export default function BulkAddEnrichmentPreview({
         setFactEdits(prev => ({ ...prev, [word]: { ...cached } }));
         return;
       }
-      void refreshWord(word, nextType);
+      void refreshWord(word, { refreshImages: false, refreshFact: true, factType: nextType });
     },
     [factCache, refreshWord, rows]
   );
@@ -472,6 +546,7 @@ export default function BulkAddEnrichmentPreview({
               : null;
           const canApproveFact = factValue.trim().length > 0;
           const isRefreshing = refreshingWord === row.word;
+          const refreshingMode = isRefreshing ? refreshingKind : null;
           const primaryWord = row.translation || row.word;
           const secondaryWord = row.translation ? row.word : "";
 
@@ -486,18 +561,26 @@ export default function BulkAddEnrichmentPreview({
                   <button
                     type="button"
                     className="enrichment-button enrichment-button--ghost"
-                    onClick={() => refreshWord(row.word, factType)}
+                    onClick={() => refreshWord(row.word, { refreshImages: true, refreshFact: false })}
                     disabled={isRefreshing || disableGlobalActions}
                   >
-                    {isRefreshing ? "Refreshing…" : "New suggestions"}
+                    {isRefreshing
+                      ? refreshingMode === "images"
+                        ? "Refreshing images…"
+                        : "Refreshing…"
+                      : "New image suggestions"}
                   </button>
                   <button
                     type="button"
-                    className="enrichment-button enrichment-button--text"
-                    onClick={() => resetFactToSuggestion(row.word)}
-                    disabled={isRefreshing}
+                    className="enrichment-button enrichment-button--ghost"
+                    onClick={() => refreshWord(row.word, { refreshImages: false, refreshFact: true, factType })}
+                    disabled={isRefreshing || disableGlobalActions}
                   >
-                    Reset fact text
+                    {isRefreshing
+                      ? refreshingMode === "fact"
+                        ? "Refreshing fact…"
+                        : "Refreshing…"
+                      : "New fact suggestion"}
                   </button>
                 </div>
               </div>
@@ -585,13 +668,21 @@ export default function BulkAddEnrichmentPreview({
                     }
                     disabled={isRefreshing}
                   />
-                  <div className="enrichment-fact-footer">
-                    <span>{factValue.length}/220 characters</span>
-                    <select
-                      value={factType}
-                      onChange={e => handleFactTypeChange(row.word, e.target.value as Fact["type"])}
-                      disabled={isRefreshing || disableGlobalActions}
-                    >
+                <div className="enrichment-fact-footer">
+                  <span>{factValue.length}/220 characters</span>
+                  <button
+                    type="button"
+                    className="enrichment-button enrichment-button--ghost"
+                    onClick={() => resetFactToSuggestion(row.word)}
+                    disabled={isRefreshing}
+                  >
+                    Reset fact text
+                  </button>
+                  <select
+                    value={factType}
+                    onChange={e => handleFactTypeChange(row.word, e.target.value as Fact["type"])}
+                    disabled={isRefreshing || disableGlobalActions}
+                  >
                       <option value="etymology">etymology</option>
                       <option value="idiom">idiom</option>
                       <option value="trivia">trivia</option>

--- a/learning/api/enrichment.py
+++ b/learning/api/enrichment.py
@@ -14,6 +14,12 @@ class PreviewEntrySerializer(serializers.Serializer):
     word = serializers.CharField(allow_blank=False, trim_whitespace=True, max_length=100)
     translation = serializers.CharField(required=False, allow_blank=True, trim_whitespace=True, max_length=100)
     fact_type = serializers.ChoiceField(choices=("etymology", "idiom", "trivia"), required=False)
+    exclude_images = serializers.ListField(
+        child=serializers.URLField(),
+        required=False,
+        allow_empty=True,
+        max_length=50,
+    )
 
 
 class PreviewRequestSerializer(serializers.Serializer):

--- a/learning/services/enrichment.py
+++ b/learning/services/enrichment.py
@@ -7,6 +7,8 @@ import logging
 import os
 import time
 
+from django.utils.translation import get_language_info
+
 from .gemini_facts import get_fact
 from .wikimedia_images import search_images
 
@@ -19,11 +21,45 @@ IMG_LIMIT = int(os.getenv("ENRICH_IMG_LIMIT", "3"))
 
 _FACT_TYPES = {"etymology", "idiom", "trivia"}
 
-def _safe_images(word: str) -> List[Dict[str, str]]:
+
+def _language_label(code: Optional[str]) -> str:
+    if not code:
+        return ""
     try:
-        return search_images(word, limit=IMG_LIMIT)
+        info = get_language_info(code)
+    except Exception:
+        info = None
+    if not info:
+        return code or ""
+    return info.get("name_local") or info.get("name") or (code or "")
+
+def _safe_images(payload: Any) -> List[Dict[str, str]]:
+    try:
+        if isinstance(payload, dict):
+            query = (payload.get("word") or payload.get("query") or "").strip()
+            source_word = (payload.get("source_word") or "").strip()
+            context_hint = payload.get("context_hint") or payload.get("context") or None
+            exclude = payload.get("exclude") or []
+        else:
+            query = str(payload or "").strip()
+            source_word = ""
+            context_hint = None
+            exclude = []
+        cleaned_exclude = [
+            str(url).strip()
+            for url in (exclude or [])
+            if isinstance(url, str) and url and str(url).strip()
+        ]
+        return search_images(
+            query,
+            limit=IMG_LIMIT,
+            source_word=source_word or None,
+            context_hint=context_hint or None,
+            exclude_urls=cleaned_exclude,
+        )
     except Exception as e:
-        logger.warning("image search failed for %r: %s", word, e)
+        query = payload.get("word") if isinstance(payload, dict) else payload
+        logger.warning("image search failed for %r: %s", query, e)
         return []
 
 def _safe_fact(payload: Dict[str, Any]) -> Dict[str, Any]:
@@ -35,13 +71,49 @@ def _safe_fact(payload: Dict[str, Any]) -> Dict[str, Any]:
             and not (result.get("text") or "").strip()
         ):
             return {"text": "No idiom available.", "type": "idiom", "confidence": 0.0}
+        text = (result.get("text") or "").strip()
+        if not text:
+            return _fallback_fact(payload)
+        result["text"] = text
+        rtype = (result.get("type") or "").strip().lower()
+        if rtype not in _FACT_TYPES:
+            result["type"] = preferred if preferred in _FACT_TYPES and preferred != "idiom" else "trivia"
+        if "confidence" not in result or not isinstance(result.get("confidence"), (int, float)):
+            result["confidence"] = 0.0
         return result
     except Exception as e:
         logger.warning("fact generation failed for %r: %s", payload.get("word"), e)
         preferred = payload.get("preferred_type")
         fallback = preferred if preferred in _FACT_TYPES else "trivia"
-        text = "No idiom available." if fallback == "idiom" else ""
-        return {"text": text, "type": fallback, "confidence": 0.0}
+        if fallback == "idiom":
+            return {"text": "No idiom available.", "type": "idiom", "confidence": 0.0}
+        adjusted = dict(payload)
+        adjusted["preferred_type"] = fallback
+        return _fallback_fact(adjusted)
+
+
+def _fallback_fact(payload: Dict[str, Any]) -> Dict[str, Any]:
+    word = (payload.get("word") or "").strip()
+    translation = (payload.get("translation") or "").strip()
+    source_label = _language_label(payload.get("source_language")) or (
+        payload.get("source_language") or "the source language"
+    )
+    target_label = _language_label(payload.get("target_language")) or (
+        payload.get("target_language") or "the target language"
+    )
+    fact_type = payload.get("preferred_type")
+    if fact_type not in _FACT_TYPES or fact_type == "idiom":
+        fact_type = "trivia"
+    if translation:
+        text = f'In {target_label}, "{word}" means "{translation}" in {source_label}.'
+    elif word and target_label:
+        text = f'"{word}" is a useful {target_label} word to teach.'
+    else:
+        text = f'Add your own fun fact about "{word}".'
+    if len(text) > 220:
+        text = text[:220].rstrip()
+    return {"text": text, "type": fact_type, "confidence": 0.1}
+
 
 def _with_timeout(fn, arg, timeout: float):
     """Run fn(arg) with a hard timeout; return None on timeout/error."""
@@ -75,14 +147,25 @@ def enrich_one(
         return {}
     translation = (entry.get("translation") or "").strip()
     requested_type = _normalize_fact_type(entry.get("fact_type"))
-    fact_word = translation or w
-    source_term = w if translation else translation
+    fact_word = w
+    source_term = translation or None
 
-    image_query = translation or w
+    exclude_images_raw = entry.get("exclude_images") or []
+    exclude_images = [
+        str(url).strip()
+        for url in exclude_images_raw
+        if isinstance(url, str) and url and str(url).strip()
+    ]
+    image_payload = {"word": w, "exclude": exclude_images}
 
     # run images + fact in parallel, each time-boxed
     with ThreadPoolExecutor(max_workers=2) as ex:
-        fi = ex.submit(_with_timeout, _safe_images, image_query, PER_WORD_TIMEOUT)
+        fi = ex.submit(
+            _with_timeout,
+            _safe_images,
+            image_payload,
+            PER_WORD_TIMEOUT,
+        )
         ff = ex.submit(
             _with_timeout,
             _safe_fact,
@@ -117,11 +200,24 @@ def get_enrichments(
                 continue
             translation = (item.get("translation") or "").strip()
             fact_type = _normalize_fact_type(item.get("fact_type"))
-            clean.append({"word": word, "translation": translation, "fact_type": fact_type})
+            exclude_raw = item.get("exclude_images") or []
+            exclude_images = [
+                str(url).strip()
+                for url in exclude_raw
+                if isinstance(url, str) and url and str(url).strip()
+            ]
+            clean.append(
+                {
+                    "word": word,
+                    "translation": translation,
+                    "fact_type": fact_type,
+                    "exclude_images": exclude_images,
+                }
+            )
         elif isinstance(item, str):
             word = item.strip()
             if word:
-                clean.append({"word": word, "translation": "", "fact_type": None})
+                clean.append({"word": word, "translation": "", "fact_type": None, "exclude_images": []})
 
     if not clean:
         return []

--- a/learning/tests/test_enrichment_service.py
+++ b/learning/tests/test_enrichment_service.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from unittest import mock
+
+from django.test import SimpleTestCase
+
+from learning.services import enrichment
+
+
+class EnrichmentServiceTests(SimpleTestCase):
+    @mock.patch("learning.services.enrichment.search_images", return_value=[])
+    @mock.patch(
+        "learning.services.enrichment.get_fact",
+        return_value={"text": "", "type": "trivia", "confidence": 0.4},
+    )
+    def test_enrich_one_uses_fallback_fact_when_empty(
+        self,
+        mock_get_fact: mock.Mock,
+        mock_search_images: mock.Mock,
+    ) -> None:
+        result = enrichment.enrich_one(
+            {"word": "plane", "translation": "avion"},
+            source_language="en",
+            target_language="fr",
+        )
+
+        self.assertEqual(result["word"], "plane")
+        self.assertEqual(result["translation"], "avion")
+        self.assertIn("plane", result["fact"]["text"])
+        self.assertIn("avion", result["fact"]["text"])
+        self.assertEqual(result["fact"]["type"], "trivia")
+        self.assertGreaterEqual(result["fact"]["confidence"], 0)
+
+        mock_get_fact.assert_called_once()
+        called_kwargs = mock_get_fact.call_args.kwargs
+        self.assertEqual(called_kwargs.get("word"), "plane")
+        self.assertEqual(called_kwargs.get("translation"), "avion")
+
+        mock_search_images.assert_called_once()
+        args, kwargs = mock_search_images.call_args
+        self.assertEqual(args[0], "plane")
+        self.assertEqual(kwargs.get("exclude_urls"), [])

--- a/learning/tests/test_wikimedia_images.py
+++ b/learning/tests/test_wikimedia_images.py
@@ -21,7 +21,7 @@ class FakeResponse:
 
 
 class WikimediaImageSearchTests(SimpleTestCase):
-    @mock.patch("learning.services.wikimedia_images.requests.get")
+    @mock.patch("learning.services.wikimedia_images.SESSION.get")
     def test_primary_query_returns_images(self, mock_get: mock.Mock) -> None:
         mock_get.return_value = FakeResponse(
             {
@@ -53,13 +53,14 @@ class WikimediaImageSearchTests(SimpleTestCase):
                     "thumb": "https://example.com/dog-thumb.jpg",
                     "source": "Wikimedia",
                     "attribution": "Photographer",
+                    "attribution_text": "Photographer",
                     "license": "CC-BY",
                 }
             ],
         )
         mock_get.assert_called_once()
 
-    @mock.patch("learning.services.wikimedia_images.requests.get")
+    @mock.patch("learning.services.wikimedia_images.SESSION.get")
     def test_fallback_query_uses_search_titles(self, mock_get: mock.Mock) -> None:
         mock_get.side_effect = [
             FakeResponse({"query": {"pages": {}}}),
@@ -94,12 +95,63 @@ class WikimediaImageSearchTests(SimpleTestCase):
                     "thumb": "https://example.com/dog-2.jpg",
                     "source": "Wikimedia",
                     "attribution": "Wikimedia",
+                    "attribution_text": "Wikimedia",
                     "license": "CC0",
                 }
             ],
         )
         self.assertEqual(mock_get.call_count, 3)
 
-    @mock.patch("learning.services.wikimedia_images.requests.get", side_effect=Exception("boom"))
+    @mock.patch("learning.services.wikimedia_images.SESSION.get")
+    def test_exclude_urls_filters_previous_results(self, mock_get: mock.Mock) -> None:
+        mock_get.return_value = FakeResponse(
+            {
+                "query": {
+                    "pages": {
+                        "1": {
+                            "imageinfo": [
+                                {
+                                    "url": "https://example.com/dog-old.jpg",
+                                    "thumburl": "https://example.com/dog-old-thumb.jpg",
+                                    "extmetadata": {"Artist": {"value": "Old"}},
+                                }
+                            ]
+                        },
+                        "2": {
+                            "imageinfo": [
+                                {
+                                    "url": "https://example.com/dog-new.jpg",
+                                    "thumburl": "https://example.com/dog-new-thumb.jpg",
+                                    "extmetadata": {"Artist": {"value": "New"}},
+                                }
+                            ]
+                        },
+                    }
+                }
+            }
+        )
+
+        results = wikimedia_images.search_images(
+            "dog",
+            limit=2,
+            exclude_urls=["https://example.com/dog-old.jpg"],
+        )
+
+        self.assertEqual(
+            results,
+            [
+                {
+                    "url": "https://example.com/dog-new.jpg",
+                    "thumb": "https://example.com/dog-new-thumb.jpg",
+                    "source": "Wikimedia",
+                    "attribution": "New",
+                    "attribution_text": "New",
+                    "license": "",
+                }
+            ],
+        )
+        self.assertEqual(mock_get.call_count, 1)
+
+    @mock.patch("learning.services.wikimedia_images.SESSION.get", side_effect=Exception("boom"))
     def test_request_error_returns_empty_list(self, mock_get: mock.Mock) -> None:  # noqa: ARG002
         self.assertEqual(wikimedia_images.search_images("cat"), [])


### PR DESCRIPTION
## Summary
- track previously rejected images and split per-word refresh actions in the enrichment preview UI so new image or fact suggestions send exclusion lists and expose a dedicated reset button
- limit enrichment image lookups to the English vocabulary term while still honoring cleaned exclusion URLs
- update the enrichment service test expectations for the new English-only image search behavior

## Testing
- python manage.py test learning.tests

------
https://chatgpt.com/codex/tasks/task_e_68c93d65e53483258bde173cc1e936e8