### PR TITLE
Disable fact enrichment and update UI

### DIFF
--- a/learning/templates/learning/add_words_to_list.html
+++ b/learning/templates/learning/add_words_to_list.html
@@ -316,6 +316,21 @@
     }
   }
 
+  .enrichment-fact.is-disabled {
+    opacity: 0.6;
+    background-color: #f8fafc;
+  }
+
+  .enrichment-fact.is-disabled .enrichment-fact-text {
+    background-color: #f1f5f9;
+  }
+
+  .enrichment-fact.is-disabled .enrichment-button,
+  .enrichment-fact.is-disabled select,
+  .enrichment-fact.is-disabled input {
+    cursor: not-allowed;
+  }
+
   .enrichment-label {
     font-size: 12px;
     font-weight: 600;

--- a/learning/templates/learning/edit_vocabulary_words.html
+++ b/learning/templates/learning/edit_vocabulary_words.html
@@ -501,6 +501,21 @@
       gap: 12px;
     }
 
+    .enrichment-fact.is-disabled {
+      opacity: 0.6;
+      background-color: #f8fafc;
+    }
+
+    .enrichment-fact.is-disabled .enrichment-fact-text {
+      background-color: #f1f5f9;
+    }
+
+    .enrichment-fact.is-disabled .enrichment-button,
+    .enrichment-fact.is-disabled select,
+    .enrichment-fact.is-disabled input {
+      cursor: not-allowed;
+    }
+
     .enrichment-label {
       font-size: 12px;
       font-weight: 600;

--- a/learning/tests/test_enrichment_service.py
+++ b/learning/tests/test_enrichment_service.py
@@ -9,13 +9,8 @@ from learning.services import enrichment
 
 class EnrichmentServiceTests(SimpleTestCase):
     @mock.patch("learning.services.enrichment.search_images", return_value=[])
-    @mock.patch(
-        "learning.services.enrichment.get_fact",
-        return_value={"text": "", "type": "trivia", "confidence": 0.4},
-    )
-    def test_enrich_one_uses_fallback_fact_when_empty(
+    def test_enrich_one_returns_placeholder_fact_when_generation_disabled(
         self,
-        mock_get_fact: mock.Mock,
         mock_search_images: mock.Mock,
     ) -> None:
         result = enrichment.enrich_one(
@@ -26,15 +21,9 @@ class EnrichmentServiceTests(SimpleTestCase):
 
         self.assertEqual(result["word"], "plane")
         self.assertEqual(result["translation"], "avion")
-        self.assertIn("plane", result["fact"]["text"])
-        self.assertIn("avion", result["fact"]["text"])
         self.assertEqual(result["fact"]["type"], "trivia")
-        self.assertGreaterEqual(result["fact"]["confidence"], 0)
-
-        mock_get_fact.assert_called_once()
-        called_kwargs = mock_get_fact.call_args.kwargs
-        self.assertEqual(called_kwargs.get("word"), "plane")
-        self.assertEqual(called_kwargs.get("translation"), "avion")
+        self.assertEqual(result["fact"]["text"], "")
+        self.assertEqual(result["fact"]["confidence"], 0.0)
 
         mock_search_images.assert_called_once()
         args, kwargs = mock_search_images.call_args

--- a/static/js/bulk_enrichment_preview.jsx
+++ b/static/js/bulk_enrichment_preview.jsx
@@ -21,19 +21,17 @@ function extractImageUrls(list) {
     .filter(Boolean);
 }
 
+const FACT_FEATURE_TOOLTIP = "Feature coming soon!";
+
 function BulkAddEnrichmentPreview({ entries, listId, onClose, fetchImpl }) {
   const fetchFn = fetchImpl || fetch;
   const [rows, setRows] = useState([]);
   const [selectedImage, setSelectedImage] = useState({});
   const [approveImage, setApproveImage] = useState({});
-  const [factEdits, setFactEdits] = useState({});
-  const [approveFact, setApproveFact] = useState({});
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState(null);
   const [refreshingWord, setRefreshingWord] = useState(null);
-  const [refreshingKind, setRefreshingKind] = useState(null);
-  const [factCache, setFactCache] = useState({});
   const [imageHistory, setImageHistory] = useState({});
 
   const approveAllSelectedImages = useCallback(() => {
@@ -49,20 +47,6 @@ function BulkAddEnrichmentPreview({ entries, listId, onClose, fetchImpl }) {
     });
   }, [rows, selectedImage]);
 
-  const approveAllFacts = useCallback(() => {
-    setApproveFact(prev => {
-      const next = Object.assign({}, prev);
-      (rows || []).forEach(row => {
-        const factState = factEdits[row.word] || {};
-        const text = factState.text || "";
-        if (text.trim()) {
-          next[row.word] = true;
-        }
-      });
-      return next;
-    });
-  }, [factEdits, rows]);
-
   const fetchPreviewFor = useCallback(
     async (targetEntries) => {
       const payloadEntries = (targetEntries || [])
@@ -75,12 +59,10 @@ function BulkAddEnrichmentPreview({ entries, listId, onClose, fetchImpl }) {
             return null;
           }
           const translation = (item.translation || "").trim();
-          const factType = item.factType;
-          const validType = factType && ["etymology", "idiom", "trivia"].includes(factType) ? factType : undefined;
           const excludeImages = (item.excludeImages || [])
             .map((url) => (url ? String(url).trim() : ""))
             .filter(Boolean);
-          const payload = { word, translation, fact_type: validType };
+          const payload = { word, translation };
           if (excludeImages.length) {
             payload.exclude_images = excludeImages;
           }
@@ -134,30 +116,17 @@ function BulkAddEnrichmentPreview({ entries, listId, onClose, fetchImpl }) {
 
   const applyInitialRows = useCallback((rowsData) => {
     const initSel = {};
-    const initFact = {};
-    const initCache = {};
     const initHistory = {};
 
     (rowsData || []).forEach((item) => {
       const images = Array.isArray(item.images) ? item.images : [];
       initSel[item.word] = images[0] || null;
-      initFact[item.word] = Object.assign({}, item.fact || {});
-      if (item.fact && item.fact.type) {
-        initCache[item.word] = {
-          [item.fact.type]: Object.assign({}, item.fact),
-        };
-      } else {
-        initCache[item.word] = {};
-      }
       initHistory[item.word] = Array.from(new Set(extractImageUrls(images)));
     });
 
     setRows(rowsData);
     setSelectedImage(initSel);
-    setFactEdits(initFact);
     setApproveImage({});
-    setApproveFact({});
-    setFactCache(initCache);
     setImageHistory(initHistory);
   }, []);
 
@@ -179,10 +148,7 @@ function BulkAddEnrichmentPreview({ entries, listId, onClose, fetchImpl }) {
         }
         setRows([]);
         setSelectedImage({});
-        setFactEdits({});
         setApproveImage({});
-        setApproveFact({});
-        setFactCache({});
         setImageHistory({});
         setError(err && err.message ? err.message : "Failed to load preview");
       } finally {
@@ -198,8 +164,7 @@ function BulkAddEnrichmentPreview({ entries, listId, onClose, fetchImpl }) {
   }, [entries, fetchPreviewFor, applyInitialRows]);
 
   const refreshWord = useCallback(
-    async (word, options = {}) => {
-      const { refreshImages = true, refreshFact = true, factType } = options;
+    async (word) => {
       if (!word) {
         return;
       }
@@ -209,25 +174,16 @@ function BulkAddEnrichmentPreview({ entries, listId, onClose, fetchImpl }) {
       const fallbackEntry = (entries || []).find((item) => item.word === word);
       const translation = (existingRow && existingRow.translation) || (fallbackEntry && fallbackEntry.translation) || "";
       const cleanedWord = word.trim();
-      const effectiveFactType =
-        factType ||
-        (factEdits[word] && factEdits[word].type) ||
-        (existingRow && existingRow.fact && existingRow.fact.type) ||
-        "trivia";
       const knownExclusions = imageHistory[word] || [];
-      const excludeImages = refreshImages
-        ? Array.from(new Set([...knownExclusions, ...extractImageUrls(existingRow && existingRow.images)]))
-        : [];
+      const excludeImages = Array.from(
+        new Set([...knownExclusions, ...extractImageUrls(existingRow && existingRow.images)])
+      );
 
       try {
         setError(null);
         setRefreshingWord(word);
-        setRefreshingKind(refreshImages && refreshFact ? "both" : refreshImages ? "images" : "fact");
         const requestEntry = { word, translation };
-        if (refreshFact) {
-          requestEntry.factType = effectiveFactType;
-        }
-        if (refreshImages && excludeImages.length) {
+        if (excludeImages.length) {
           requestEntry.excludeImages = excludeImages;
         }
         const rowsData = await fetchPreviewFor([requestEntry]);
@@ -242,27 +198,9 @@ function BulkAddEnrichmentPreview({ entries, listId, onClose, fetchImpl }) {
         });
 
         const patchedImages = Array.isArray(patchedRow.images) ? patchedRow.images : [];
-        const existingImages = Array.isArray(existingRow && existingRow.images) ? existingRow.images : [];
-        const nextImages = refreshImages ? patchedImages : (existingImages.length ? existingImages : patchedImages);
-        const nextFact = refreshFact ? patchedRow.fact : (existingRow && existingRow.fact) || patchedRow.fact;
-        const resolvedFact = {
-          text: nextFact && nextFact.text ? nextFact.text.trim() : "",
-          type: (nextFact && nextFact.type) || effectiveFactType,
-          confidence:
-            typeof (nextFact && nextFact.confidence) === "number"
-              ? nextFact.confidence
-              : typeof (existingRow && existingRow.fact && existingRow.fact.confidence) === "number"
-              ? existingRow.fact.confidence
-              : typeof (patchedRow.fact && patchedRow.fact.confidence) === "number"
-              ? patchedRow.fact.confidence
-              : 0,
-        };
-        const nextRow = {
-          word: cleanedWord,
-          translation: patchedRow.translation || "",
-          images: nextImages,
-          fact: resolvedFact,
-        };
+        const nextRow = Object.assign({}, patchedRow, {
+          images: patchedImages,
+        });
 
         setRows((prev = []) => {
           const exists = prev.some((r) => r.word === cleanedWord);
@@ -272,49 +210,27 @@ function BulkAddEnrichmentPreview({ entries, listId, onClose, fetchImpl }) {
           return prev.map((r) => (r.word === cleanedWord ? nextRow : r));
         });
 
-        if (refreshImages) {
-          const candidates = Array.isArray(nextImages) ? nextImages : [];
-          setSelectedImage((prev) =>
-            Object.assign({}, prev, {
-              [cleanedWord]: candidates[0] || null,
-            })
-          );
-          setApproveImage((prev) => Object.assign({}, prev, { [cleanedWord]: false }));
-          setImageHistory((prev) => {
-            const next = Object.assign({}, prev);
-            const existing = Array.isArray(prev[cleanedWord]) ? prev[cleanedWord] : [];
-            const merged = Array.from(new Set([...existing, ...excludeImages, ...extractImageUrls(candidates)]));
-            next[cleanedWord] = merged;
-            return next;
-          });
-        }
-
-        if (refreshFact) {
-          const baseFact = Object.assign({}, resolvedFact);
-          setFactEdits((prev) =>
-            Object.assign({}, prev, {
-              [cleanedWord]: Object.assign({}, baseFact),
-            })
-          );
-          setApproveFact((prev) => Object.assign({}, prev, { [cleanedWord]: false }));
-          setFactCache((prev) => {
-            const next = Object.assign({}, prev);
-            const existing = Object.assign({}, next[cleanedWord] || {});
-            if (baseFact.type) {
-              existing[baseFact.type] = Object.assign({}, baseFact);
-            }
-            next[cleanedWord] = existing;
-            return next;
-          });
-        }
+        const candidates = Array.isArray(patchedImages) ? patchedImages : [];
+        setSelectedImage((prev) =>
+          Object.assign({}, prev, {
+            [cleanedWord]: candidates[0] || null,
+          })
+        );
+        setApproveImage((prev) => Object.assign({}, prev, { [cleanedWord]: false }));
+        setImageHistory((prev) => {
+          const next = Object.assign({}, prev);
+          const existing = Array.isArray(prev[cleanedWord]) ? prev[cleanedWord] : [];
+          const merged = Array.from(new Set([...existing, ...excludeImages, ...extractImageUrls(candidates)]));
+          next[cleanedWord] = merged;
+          return next;
+        });
       } catch (err) {
         setError(err && err.message ? err.message : "Failed to refresh suggestions");
       } finally {
         setRefreshingWord(null);
-        setRefreshingKind(null);
       }
     },
-    [entries, factEdits, fetchPreviewFor, imageHistory, rows]
+    [entries, fetchPreviewFor, imageHistory, rows]
   );
 
   const reloadAll = useCallback(async () => {
@@ -324,7 +240,6 @@ function BulkAddEnrichmentPreview({ entries, listId, onClose, fetchImpl }) {
           word: row.word,
           translation:
             row.translation || ((entries || []).find((item) => item.word === row.word)?.translation || ""),
-          factType: (factEdits[row.word] && factEdits[row.word].type) || (row.fact && row.fact.type),
         }))
       : (entries || []);
 
@@ -342,83 +257,24 @@ function BulkAddEnrichmentPreview({ entries, listId, onClose, fetchImpl }) {
     } finally {
       setLoading(false);
     }
-  }, [applyInitialRows, entries, factEdits, fetchPreviewFor, rows]);
-
-  const resetFactToSuggestion = (word) => {
-    const row = (rows || []).find((item) => item.word === word);
-    if (!row) {
-      return;
-    }
-    const currentType = (factEdits[word] && factEdits[word].type) || (row.fact && row.fact.type) || "trivia";
-    const cached = factCache[word] && factCache[word][currentType];
-    setApproveFact((prev) => Object.assign({}, prev, { [word]: false }));
-    if (cached) {
-      setFactEdits((prev) => Object.assign({}, prev, { [word]: Object.assign({}, cached) }));
-      return;
-    }
-    setFactEdits((prev) => {
-      const next = Object.assign({}, prev);
-      const existing = Object.assign({}, prev[word] || {});
-      existing.type = currentType;
-      existing.text = "";
-      if (typeof existing.confidence !== "number") {
-        existing.confidence = row.fact && row.fact.confidence;
-      }
-      next[word] = existing;
-      return next;
-    });
-    refreshWord(word, { refreshImages: false, refreshFact: true, factType: currentType });
-  };
+  }, [applyInitialRows, entries, fetchPreviewFor, rows]);
 
   const clearImageSelection = (word) => {
     setSelectedImage((prev) => Object.assign({}, prev, { [word]: null }));
     setApproveImage((prev) => Object.assign({}, prev, { [word]: false }));
   };
 
-  const handleFactTypeChange = useCallback(
-    (word, nextType) => {
-      if (!word || !nextType) {
-        return;
-      }
-      const baseRow = (rows || []).find((item) => item.word === word);
-      setFactEdits((prev) => {
-        const next = Object.assign({}, prev);
-        const current = Object.assign({}, prev[word] || {});
-        current.type = nextType;
-        current.text = "";
-        if (typeof current.confidence !== "number") {
-          current.confidence = baseRow && baseRow.fact ? baseRow.fact.confidence : current.confidence;
-        }
-        next[word] = current;
-        return next;
-      });
-      setApproveFact((prev) => Object.assign({}, prev, { [word]: false }));
-      const cached = factCache[word] && factCache[word][nextType];
-      if (cached) {
-        setFactEdits((prev) => Object.assign({}, prev, { [word]: Object.assign({}, cached) }));
-        return;
-      }
-      refreshWord(word, { refreshImages: false, refreshFact: true, factType: nextType });
-    },
-    [factCache, refreshWord, rows]
-  );
-
   const onConfirm = async () => {
     try {
       setSaving(true);
       setError(null);
-      const items = (rows || []).map((r) => {
-        const fact = factEdits[r.word] || {};
-        const factText = (fact.text || "").trim();
-        return {
-          word: r.word,
-          translation: r.translation || "",
-          image: selectedImage[r.word],
-          fact,
-          approveImage: Boolean(approveImage[r.word] && selectedImage[r.word]),
-          approveFact: Boolean(approveFact[r.word] && factText),
-        };
-      });
+      const items = (rows || []).map((r) => ({
+        word: r.word,
+        translation: r.translation || "",
+        image: selectedImage[r.word],
+        approveImage: Boolean(approveImage[r.word] && selectedImage[r.word]),
+        approveFact: false,
+      }));
       const headers = { "Content-Type": "application/json" };
       const csrfToken = getCookie("csrftoken");
       if (csrfToken) {
@@ -447,11 +303,6 @@ function BulkAddEnrichmentPreview({ entries, listId, onClose, fetchImpl }) {
 
   const disableGlobalActions = Boolean(refreshingWord) || saving;
   const canBulkApproveImages = (rows || []).some((row) => Boolean(selectedImage[row.word]));
-  const canBulkApproveFacts = (rows || []).some((row) => {
-    const factState = factEdits[row.word] || {};
-    const text = factState.text || "";
-    return Boolean(text.trim());
-  });
 
   return (
     <div className="enrichment-preview">
@@ -472,8 +323,9 @@ function BulkAddEnrichmentPreview({ entries, listId, onClose, fetchImpl }) {
           <button
             type="button"
             className="enrichment-button enrichment-button--ghost"
-            onClick={approveAllFacts}
-            disabled={disableGlobalActions || !canBulkApproveFacts}
+            disabled
+            aria-disabled="true"
+            title={FACT_FEATURE_TOOLTIP}
           >
             Accept all facts
           </button>
@@ -507,20 +359,17 @@ function BulkAddEnrichmentPreview({ entries, listId, onClose, fetchImpl }) {
       ) : (
         rows.map(row => {
           const currentImage = selectedImage[row.word] || null;
-          const factState = factEdits[row.word] || {};
-          const factValue = factState.text || "";
-          const factType = factState.type || (row.fact && row.fact.type) || "trivia";
+          const factValue = row.fact && row.fact.text ? String(row.fact.text) : "";
+          const factType = (row.fact && row.fact.type) || "trivia";
           const factConfidence =
-            typeof factState.confidence === "number"
-              ? factState.confidence
-              : row.fact && row.fact.confidence;
+            typeof (row.fact && row.fact.confidence) === "number"
+              ? row.fact.confidence
+              : 0;
           const confidenceLabel =
             typeof factConfidence === "number" && !Number.isNaN(factConfidence)
               ? `${Math.round(Math.max(0, Math.min(1, factConfidence)) * 100)}% confidence`
               : null;
-          const canApproveFact = factValue.trim().length > 0;
           const isRefreshing = refreshingWord === row.word;
-          const refreshingMode = isRefreshing ? refreshingKind : null;
           const primaryWord = row.translation || row.word;
           const secondaryWord = row.translation ? row.word : "";
 
@@ -535,26 +384,19 @@ function BulkAddEnrichmentPreview({ entries, listId, onClose, fetchImpl }) {
                   <button
                     type="button"
                     className="enrichment-button enrichment-button--ghost"
-                    onClick={() => refreshWord(row.word, { refreshImages: true, refreshFact: false })}
+                    onClick={() => refreshWord(row.word)}
                     disabled={isRefreshing || disableGlobalActions}
                   >
-                    {isRefreshing
-                      ? refreshingMode === "images"
-                        ? "Refreshing images…"
-                        : "Refreshing…"
-                      : "New image suggestions"}
+                    {isRefreshing ? "Refreshing images…" : "New image suggestions"}
                   </button>
                   <button
                     type="button"
                     className="enrichment-button enrichment-button--ghost"
-                    onClick={() => refreshWord(row.word, { refreshImages: false, refreshFact: true, factType })}
-                    disabled={isRefreshing || disableGlobalActions}
+                    disabled
+                    aria-disabled="true"
+                    title={FACT_FEATURE_TOOLTIP}
                   >
-                    {isRefreshing
-                      ? refreshingMode === "fact"
-                        ? "Refreshing fact…"
-                        : "Refreshing…"
-                      : "New fact suggestion"}
+                    New fact suggestion
                   </button>
                 </div>
               </div>
@@ -617,7 +459,11 @@ function BulkAddEnrichmentPreview({ entries, listId, onClose, fetchImpl }) {
                   </div>
                 </div>
 
-                <div className="enrichment-fact">
+                <div
+                  className="enrichment-fact is-disabled"
+                  title={FACT_FEATURE_TOOLTIP}
+                  aria-disabled="true"
+                >
                   <span className="enrichment-label">Word fact</span>
                   <div className="enrichment-fact-meta">
                     <span className="enrichment-badge" data-type={factType}>
@@ -629,44 +475,35 @@ function BulkAddEnrichmentPreview({ entries, listId, onClose, fetchImpl }) {
                     className="enrichment-fact-text"
                     maxLength={220}
                     value={factValue}
-                    onChange={e =>
-                      setFactEdits(prev => Object.assign({}, prev, {
-                        [row.word]: Object.assign({}, prev[row.word] || { type: factType }, {
-                          text: e.target.value,
-                          type: factType,
-                          confidence: factConfidence,
-                        }),
-                      }))
-                    }
-                    disabled={isRefreshing}
+                    readOnly
+                    disabled
+                    title={FACT_FEATURE_TOOLTIP}
                   />
                   <div className="enrichment-fact-footer">
                     <span>{factValue.length}/220 characters</span>
                     <button
                       type="button"
                       className="enrichment-button enrichment-button--ghost"
-                      onClick={() => resetFactToSuggestion(row.word)}
-                      disabled={isRefreshing}
+                      disabled
+                      aria-disabled="true"
+                      title={FACT_FEATURE_TOOLTIP}
                     >
                       Reset fact text
                     </button>
                     <select
                       value={factType}
-                      onChange={e => handleFactTypeChange(row.word, e.target.value)}
-                      disabled={isRefreshing || disableGlobalActions}
+                      onChange={() => undefined}
+                      disabled
+                      aria-disabled="true"
+                      title={FACT_FEATURE_TOOLTIP}
                     >
                       <option value="etymology">etymology</option>
                       <option value="idiom">idiom</option>
                       <option value="trivia">trivia</option>
                     </select>
                   </div>
-                  <label className="enrichment-checkbox">
-                    <input
-                      type="checkbox"
-                      checked={Boolean(approveFact[row.word]) && canApproveFact}
-                      onChange={e => setApproveFact(prev => Object.assign({}, prev, { [row.word]: e.target.checked }))}
-                      disabled={!canApproveFact}
-                    />
+                  <label className="enrichment-checkbox" title={FACT_FEATURE_TOOLTIP}>
+                    <input type="checkbox" checked={false} readOnly disabled aria-disabled="true" />
                     Approve fact
                   </label>
                 </div>


### PR DESCRIPTION
## Summary
- stop generating vocabulary facts in the enrichment service and update the corresponding unit test
- disable all fact-related controls in the enrichment preview UI with a "Feature coming soon!" tooltip
- apply the same UI changes to the legacy JS bundle and add styling to grey out the fact panel

## Testing
- python manage.py test learning.tests.test_enrichment_service learning.tests.test_enrichment_api

------
https://chatgpt.com/codex/tasks/task_e_68c9891b3670832589d94cf8b165a7f9