### PR TITLE
Improve student bulk add handling

### DIFF
--- a/learning/utils.py
+++ b/learning/utils.py
@@ -1,12 +1,37 @@
 import random
 import string
+from datetime import date, datetime
+from typing import Union
 
-def generate_student_username(first_name, surname, day, month):
-    """
-    Generate a username for a student.
-    Format: FirstName + FirstTwoLettersOfSurname + Day + Month
-    """
-    username = f"{first_name.capitalize()}{surname[:2].capitalize()}{day:02}{month:02}"
+
+def _coerce_to_date(dob: Union[str, date, datetime]) -> date:
+    """Normalize supported date inputs to a ``date`` object."""
+
+    if isinstance(dob, date) and not isinstance(dob, datetime):
+        return dob
+    if isinstance(dob, datetime):
+        return dob.date()
+    if isinstance(dob, str):
+        dob = dob.strip()
+        try:
+            return datetime.strptime(dob, "%d/%m/%Y").date()
+        except ValueError as exc:  # pragma: no cover - defensive
+            raise ValueError("Date of birth must be in DD/MM/YYYY format.") from exc
+    raise TypeError("Date of birth must be a date, datetime, or DD/MM/YYYY string.")
+
+
+def generate_student_username(first_name, surname, day=None, month=None, dob=None):
+    """Generate a username using the student's name and date of birth details."""
+
+    if dob is not None and (day is None or month is None):
+        parsed = _coerce_to_date(dob)
+        day = parsed.day
+        month = parsed.month
+
+    if day is None or month is None:
+        raise ValueError("Day and month or a valid date of birth must be provided.")
+
+    username = f"{first_name.capitalize()}{surname[:2].capitalize()}{int(day):02}{int(month):02}"
     return username
 
 def generate_random_password(length=4):


### PR DESCRIPTION
## Summary
- allow `generate_student_username` to accept a date of birth value directly so callers cannot omit day/month pieces
- harden the student bulk add view with CSV parsing, input validation, and clearer messaging while syncing updates to existing students
- report success, reuse existing accounts, and skip duplicates so class enrollment is smoother for teachers

## Testing
- python manage.py test *(fails: ImportError: 'tests' module incorrectly imported from '/workspace/pavonify/learning/tests')*


------
https://chatgpt.com/codex/tasks/task_e_68ca19c5e9008325a26b5f724c845850