### PR TITLE
Refine peacock mini-game flow

### DIFF
--- a/learning/templates/learning/mini_game_1.html
+++ b/learning/templates/learning/mini_game_1.html
@@ -4,335 +4,635 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Peacock Conveyor Sorter - Pavonify</title>
+  <title>Peacock Feeding Frenzy - Pavonify</title>
   <style>
     @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap');
 
     :root {
-      --peacock-primary: #5a189a;
+      --peacock-primary: #54278f;
       --peacock-secondary: #7b2cbf;
       --peacock-accent: #c77dff;
       --peacock-highlight: #28a745;
       --peacock-warning: #ff2c61;
       --peacock-surface: #f3f5ff;
+      --peacock-shadow: rgba(84, 39, 143, 0.18);
+    }
+
+    * {
+      box-sizing: border-box;
     }
 
     body {
       font-family: 'Poppins', sans-serif;
       margin: 0;
-      background: var(--peacock-surface);
-      color: #2f2a4a;
+      min-height: 100vh;
+      background: radial-gradient(circle at top, rgba(199, 125, 255, 0.22), transparent 55%),
+                  var(--peacock-surface);
+      color: #231942;
       display: flex;
       justify-content: center;
-      align-items: flex-start;
-      min-height: 100vh;
-      padding: 40px 15px;
+      align-items: center;
+      padding: 40px 18px;
     }
 
-    .pane {
+    .game-shell {
+      width: min(100%, 1120px);
       background: #ffffff;
-      border-radius: 16px;
-      box-shadow: 0 15px 35px rgba(90, 24, 154, 0.15);
-      padding: 30px 24px 40px;
-      width: 100%;
-      max-width: 900px;
+      border-radius: 24px;
+      box-shadow: 0 25px 55px rgba(84, 39, 143, 0.16);
+      padding: 36px 38px 40px;
       position: relative;
-      text-align: center;
-    }
-
-    .pane h1 {
-      margin: 0;
-      font-size: 32px;
-      color: var(--peacock-primary);
-    }
-
-    .list-name {
-      margin: 8px 0 20px;
-      color: #7d7a92;
-      font-weight: 600;
-      letter-spacing: 0.4px;
-    }
-
-    .instruction {
-      font-size: 17px;
-      margin-bottom: 25px;
-      color: #4f4a6b;
+      overflow: hidden;
+      display: grid;
+      grid-template-columns: minmax(240px, 320px) minmax(0, 1fr);
+      column-gap: 38px;
+      row-gap: 28px;
+      align-items: start;
     }
 
     .back-button {
-      position: absolute;
-      left: 24px;
-      top: 24px;
-      background: #d0c4ff;
+      display: inline-flex;
+      align-items: center;
+      padding: 8px 16px;
+      border-radius: 999px;
+      background: rgba(123, 44, 191, 0.16);
       color: var(--peacock-primary);
-      padding: 8px 14px;
-      border-radius: 30px;
       text-decoration: none;
       font-weight: 600;
-      box-shadow: 0 4px 10px rgba(122, 44, 191, 0.18);
+      letter-spacing: 0.4px;
+      box-shadow: 0 8px 18px rgba(123, 44, 191, 0.18);
       transition: transform 0.2s ease, box-shadow 0.2s ease;
+      width: fit-content;
     }
 
     .back-button:hover {
       transform: translateY(-2px);
-      box-shadow: 0 8px 18px rgba(122, 44, 191, 0.22);
+      box-shadow: 0 14px 24px rgba(123, 44, 191, 0.24);
     }
 
-    .stats {
-      position: fixed;
-      top: 30px;
-      right: 30px;
-      background: #ffffff;
-      border-radius: 16px;
-      box-shadow: 0 12px 30px rgba(17, 12, 46, 0.15);
-      padding: 20px;
-      width: 240px;
-      z-index: 10;
-    }
-
-    .stats h3 {
-      margin-top: 0;
-      margin-bottom: 12px;
-      font-size: 18px;
+    h1 {
+      margin: 0;
+      font-size: 34px;
+      text-align: left;
       color: var(--peacock-primary);
     }
 
-    .stats p {
-      margin: 6px 0;
-      font-size: 14px;
+    .list-name {
+      margin: 10px 0 6px;
+      text-align: left;
+      color: #7d7a92;
+      font-weight: 600;
+      letter-spacing: 0.35px;
+    }
+
+    .instruction {
+      text-align: left;
+      color: #403f5a;
+      margin: 12px 0 8px;
+      max-width: 320px;
+      font-size: 17px;
+    }
+
+    .info-panel {
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+    }
+
+    .info-panel h1 {
+      line-height: 1.2;
+    }
+
+    .info-panel .summary {
+      display: flex;
+      gap: 18px;
+      font-weight: 600;
+      color: #46405e;
+      flex-wrap: wrap;
+    }
+
+    .info-panel .summary strong {
+      color: var(--peacock-primary);
+    }
+
+    .board-panel {
+      display: flex;
+      flex-direction: column;
+      gap: 22px;
+    }
+
+    .game-stage {
+      display: flex;
+      flex-direction: column;
+      gap: 26px;
+    }
+
+    .conveyor-area {
+      display: grid;
+      gap: 16px;
     }
 
     .conveyor {
-      margin: 35px auto 25px;
-      padding: 18px;
-      background: linear-gradient(135deg, rgba(122, 44, 191, 0.08), rgba(90, 24, 154, 0.12));
-      border-radius: 20px;
       position: relative;
+      min-height: 120px;
+      border-radius: 18px;
+      padding: 22px 16px;
+      background: linear-gradient(120deg, rgba(123, 44, 191, 0.15), rgba(90, 24, 154, 0.28));
       overflow: hidden;
+      box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.18);
     }
 
-    .belt {
-      background: linear-gradient(90deg, rgba(255, 255, 255, 0.35) 0%, rgba(255, 255, 255, 0) 60%),
-                  linear-gradient(135deg, rgba(90, 24, 154, 0.15), rgba(122, 44, 191, 0.3));
-      border-radius: 14px;
-      height: 140px;
-      max-width: 640px;
-      margin: 0 auto;
-      position: relative;
-      overflow: hidden;
-    }
-
-    .belt::before {
+    .conveyor::before,
+    .conveyor::after {
       content: "";
       position: absolute;
-      top: 50%;
-      left: 0;
-      width: 100%;
+      left: 16px;
+      right: 16px;
       height: 10px;
+      border-radius: 999px;
       background: rgba(255, 255, 255, 0.55);
-      transform: translateY(-50%);
-      opacity: 0.65;
     }
 
-    .card {
+    .conveyor::before {
+      top: 30px;
+    }
+
+    .conveyor::after {
+      bottom: 30px;
+    }
+
+    .conveyor-track {
+      position: relative;
+      width: 100%;
+      height: 100%;
+    }
+
+    .conveyor-card {
       position: absolute;
       top: 50%;
-      left: 0;
-      transform: translate(-200px, -50%);
-      background: linear-gradient(135deg, #7b2cbf, #5a189a);
-      color: #ffffff;
-      font-size: 24px;
+      padding: 16px 26px;
+      border-radius: 18px;
       font-weight: 700;
-      border-radius: 16px;
-      padding: 18px 26px;
-      box-shadow: 0 14px 28px rgba(90, 24, 154, 0.25);
-      min-width: 170px;
+      font-size: 22px;
+      background: linear-gradient(135deg, #7b2cbf, #54278f);
+      color: #ffffff;
+      box-shadow: 0 18px 36px rgba(84, 39, 143, 0.25);
+      cursor: grab;
+      user-select: none;
+    }
+
+    .conveyor-card::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      border-radius: 18px;
+      border: 2px solid rgba(255, 255, 255, 0.28);
       pointer-events: none;
-      transition: background 0.3s ease;
     }
 
-    .card.success {
-      background: var(--peacock-highlight);
-      box-shadow: 0 14px 28px rgba(40, 167, 69, 0.35);
+    .conveyor-card:active {
+      cursor: grabbing;
     }
 
-    .card.fail {
-      background: var(--peacock-warning);
-      box-shadow: 0 14px 28px rgba(255, 44, 97, 0.35);
+    .conveyor-card.dragging {
+      opacity: 0.9;
+      animation-play-state: paused;
+      box-shadow: 0 20px 45px rgba(84, 39, 143, 0.35);
     }
 
-    .bin-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-      gap: 15px;
-      margin-top: 30px;
+    .conveyor-card.inactive {
+      opacity: 0.3;
+      animation-play-state: paused;
     }
 
-    .bin {
-      border: none;
-      border-radius: 14px;
-      padding: 18px 14px;
-      font-size: 17px;
-      font-weight: 600;
-      color: #2f2a4a;
+    .conveyor-card.direction-ltr {
+      transform: translate(-110%, -50%);
+      animation: slide-left-to-right var(--duration) linear forwards;
+    }
+
+    .conveyor-card.direction-rtl {
+      transform: translate(110%, -50%);
+      animation: slide-right-to-left var(--duration) linear forwards;
+    }
+
+    @keyframes slide-left-to-right {
+      from {
+        transform: translate(-120%, -50%);
+      }
+      to {
+        transform: translate(120%, -50%);
+      }
+    }
+
+    @keyframes slide-right-to-left {
+      from {
+        transform: translate(120%, -50%);
+      }
+      to {
+        transform: translate(-120%, -50%);
+      }
+    }
+
+    .peacock-runway {
+      position: relative;
+      min-height: 240px;
+      border-radius: 24px;
+      padding: 26px 24px 36px;
+      background: linear-gradient(160deg, rgba(40, 167, 69, 0.08), rgba(199, 125, 255, 0.16));
+      box-shadow: inset 0 0 0 2px rgba(123, 44, 191, 0.12);
+      display: flex;
+      flex-wrap: wrap;
+      gap: 26px;
+      justify-content: center;
+      align-items: flex-end;
+    }
+
+    .peacock {
+      position: relative;
+      width: 170px;
+      height: 180px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: flex-end;
+      gap: 8px;
+      animation: peacock-pop 0.35s ease-out;
+    }
+
+    @keyframes peacock-pop {
+      from {
+        transform: translateY(20px) scale(0.9);
+        opacity: 0;
+      }
+      to {
+        transform: translateY(0) scale(1);
+        opacity: 1;
+      }
+    }
+
+    .timer-ring {
+      position: absolute;
+      top: -10px;
+      width: 70px;
+      height: 70px;
+      border-radius: 50%;
+      background: conic-gradient(var(--peacock-highlight) 360deg, rgba(0, 0, 0, 0.08) 0deg);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      box-shadow: 0 10px 22px rgba(84, 39, 143, 0.25);
+    }
+
+    .timer-ring.urgent {
+      animation: pulse-urgent 0.7s ease-in-out infinite;
+    }
+
+    @keyframes pulse-urgent {
+      0%, 100% {
+        box-shadow: 0 12px 26px rgba(255, 44, 97, 0.35);
+        transform: scale(1);
+      }
+      50% {
+        box-shadow: 0 16px 32px rgba(255, 44, 97, 0.45);
+        transform: scale(1.05);
+      }
+    }
+
+    .timer-ring::after {
+      content: "";
+      width: 52px;
+      height: 52px;
+      border-radius: 50%;
       background: #ffffff;
-      box-shadow: 0 10px 24px rgba(122, 44, 191, 0.12);
-      cursor: pointer;
-      transition: transform 0.15s ease, box-shadow 0.2s ease, background 0.2s ease;
+      box-shadow: inset 0 0 0 2px rgba(84, 39, 143, 0.08);
     }
 
-    .bin:hover {
-      transform: translateY(-4px);
-      box-shadow: 0 16px 30px rgba(122, 44, 191, 0.18);
+    .timer-number {
+      position: absolute;
+      font-weight: 700;
+      color: var(--peacock-primary);
+      font-size: 18px;
     }
 
-    .bin.correct {
-      background: rgba(40, 167, 69, 0.18);
-      color: var(--peacock-highlight);
-      box-shadow: 0 14px 28px rgba(40, 167, 69, 0.25);
-    }
-
-    .bin.incorrect {
-      background: rgba(255, 44, 97, 0.15);
-      color: var(--peacock-warning);
-      box-shadow: 0 14px 28px rgba(255, 44, 97, 0.22);
-    }
-
-    .bin:disabled {
-      cursor: not-allowed;
-      opacity: 0.7;
-      transform: none;
-      box-shadow: 0 10px 22px rgba(122, 44, 191, 0.1);
-    }
-
-    .status-bar {
-      margin-top: 28px;
+    .speech-bubble {
+      position: relative;
+      padding: 14px 18px;
+      background: #ffffff;
+      border-radius: 18px;
+      border: 2px solid rgba(123, 44, 191, 0.28);
+      box-shadow: 0 12px 22px rgba(84, 39, 143, 0.18);
+      min-width: 160px;
       text-align: center;
+      font-weight: 700;
+      color: var(--peacock-primary);
+      transition: transform 0.18s ease, box-shadow 0.18s ease;
+    }
+
+    .speech-bubble::after {
+      content: "";
+      position: absolute;
+      bottom: -18px;
+      left: 50%;
+      transform: translateX(-50%);
+      border-width: 18px 14px 0 14px;
+      border-style: solid;
+      border-color: #ffffff transparent transparent transparent;
+      filter: drop-shadow(0 6px 8px rgba(84, 39, 143, 0.15));
+    }
+
+    .speech-bubble.drop-hover {
+      transform: translateY(-4px) scale(1.03);
+      box-shadow: 0 18px 28px rgba(84, 39, 143, 0.28);
+      border-color: rgba(40, 167, 69, 0.55);
+    }
+
+    .speech-bubble.shake {
+      animation: shake 0.35s ease;
+    }
+
+    @keyframes shake {
+      10%, 90% { transform: translateX(-2px); }
+      20%, 80% { transform: translateX(4px); }
+      30%, 50%, 70% { transform: translateX(-6px); }
+      40%, 60% { transform: translateX(6px); }
+    }
+
+    .peacock-body {
+      width: 120px;
+      height: 120px;
+      background: rgba(123, 44, 191, 0.12);
+      border-radius: 50% 50% 45% 45%;
+      display: flex;
+      align-items: flex-end;
+      justify-content: center;
+      padding: 12px 8px 8px;
+      box-shadow: inset 0 0 0 2px rgba(123, 44, 191, 0.2);
+    }
+
+    .peacock-body img {
+      width: 100%;
+      height: auto;
+      pointer-events: none;
+    }
+
+    .peacock.fed .speech-bubble {
+      border-color: rgba(40, 167, 69, 0.6);
+      box-shadow: 0 16px 28px rgba(40, 167, 69, 0.24);
+    }
+
+    .peacock.fed .speech-bubble::after {
+      border-top-color: rgba(255, 255, 255, 0.95);
     }
 
     .feedback {
-      min-height: 28px;
+      min-height: 40px;
       font-size: 18px;
       font-weight: 600;
       color: var(--peacock-primary);
-      margin-bottom: 12px;
+      transition: color 0.2s ease;
+      text-align: left;
+      display: flex;
+      align-items: center;
     }
 
-    .summary {
-      display: inline-flex;
-      gap: 20px;
-      font-weight: 600;
-      color: #4f4a6b;
+    .feedback.success {
+      color: var(--peacock-highlight);
     }
 
-    .summary span strong {
-      color: var(--peacock-primary);
+    .feedback.warning {
+      color: var(--peacock-warning);
     }
 
     .btn {
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      padding: 10px 18px;
-      border-radius: 28px;
+      padding: 10px 22px;
+      border-radius: 999px;
       border: none;
       font-weight: 600;
       text-transform: uppercase;
+      background: linear-gradient(135deg, #7b2cbf, #54278f);
       color: #ffffff;
-      background: linear-gradient(135deg, #7b2cbf, #5a189a);
       cursor: pointer;
-      box-shadow: 0 10px 20px rgba(122, 44, 191, 0.2);
+      box-shadow: 0 16px 32px rgba(84, 39, 143, 0.24);
       transition: transform 0.2s ease, box-shadow 0.2s ease;
-      text-decoration: none;
+      letter-spacing: 0.6px;
     }
 
     .btn:hover {
       transform: translateY(-2px);
-      box-shadow: 0 14px 24px rgba(122, 44, 191, 0.28);
+      box-shadow: 0 22px 40px rgba(84, 39, 143, 0.3);
     }
 
     .play-again {
-      margin-top: 18px;
+      margin-top: 8px;
+      align-self: flex-start;
     }
 
-    @media (max-width: 992px) {
+    .start-overlay {
+      position: absolute;
+      inset: 0;
+      background: rgba(23, 19, 41, 0.72);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 24px;
+      z-index: 30;
+      backdrop-filter: blur(3px);
+    }
+
+    .start-overlay[hidden] {
+      display: none;
+    }
+
+    .start-card {
+      background: #ffffff;
+      padding: 32px 36px;
+      border-radius: 22px;
+      max-width: 420px;
+      text-align: center;
+      box-shadow: 0 22px 45px rgba(0, 0, 0, 0.25);
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+    }
+
+    .start-card h2 {
+      margin: 0;
+      font-size: 28px;
+      color: var(--peacock-primary);
+    }
+
+    .start-card p {
+      margin: 0;
+      color: #403f5a;
+    }
+
+    .countdown-display {
+      font-size: 48px;
+      font-weight: 700;
+      color: var(--peacock-primary);
+      letter-spacing: 2px;
+    }
+
+    .game-over-panel {
+      position: absolute;
+      inset: 0;
+      background: rgba(23, 19, 41, 0.75);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      backdrop-filter: blur(4px);
+      padding: 20px;
+      z-index: 20;
+    }
+
+    .game-over-card {
+      background: #ffffff;
+      padding: 32px 36px;
+      border-radius: 22px;
+      text-align: center;
+      max-width: 420px;
+      box-shadow: 0 22px 45px rgba(0, 0, 0, 0.25);
+    }
+
+    .game-over-card h2 {
+      margin-top: 0;
+      color: var(--peacock-primary);
+      font-size: 28px;
+    }
+
+    .game-over-card p {
+      margin: 12px 0;
+      color: #403f5a;
+      font-weight: 500;
+    }
+
+    .game-over-card strong {
+      color: var(--peacock-secondary);
+    }
+
+    .empty-state {
+      padding: 60px 20px 0;
+      text-align: center;
+      color: #7d7a92;
+      font-weight: 600;
+      font-size: 18px;
+    }
+
+    @media (max-width: 1080px) {
       body {
-        flex-direction: column;
-        align-items: center;
-        padding-top: 110px;
+        align-items: flex-start;
+        padding: 32px 18px 48px;
       }
 
-      .stats {
-        position: static;
-        width: calc(100% - 30px);
-        max-width: 320px;
-        margin-bottom: 25px;
+      .game-shell {
+        grid-template-columns: 1fr;
+        padding: 28px 24px 32px;
       }
 
-      .back-button {
-        position: static;
-        display: inline-flex;
-        margin-bottom: 16px;
-      }
-
-      .pane {
-        padding-top: 20px;
+      .instruction {
+        max-width: 100%;
       }
     }
 
-    @media (max-width: 600px) {
-      .pane h1 {
-        font-size: 26px;
+    @media (max-width: 640px) {
+      body {
+        padding: 28px 14px 36px;
       }
 
-      .card {
-        font-size: 20px;
-        padding: 14px 20px;
-        min-width: 140px;
+      .game-shell {
+        padding: 24px 18px 28px;
+      }
+
+      h1 {
+        font-size: 28px;
       }
 
       .instruction {
         font-size: 15px;
+        margin-bottom: 4px;
+      }
+
+      .info-panel .summary {
+        gap: 12px;
+      }
+
+      .game-stage {
+        gap: 18px;
+      }
+
+      .start-card {
+        padding: 26px 24px;
+      }
+
+      .countdown-display {
+        font-size: 40px;
+      }
+
+      .peacock {
+        width: 140px;
+        height: 160px;
+      }
+
+      .speech-bubble {
+        min-width: 130px;
+        font-size: 15px;
+      }
+
+      .conveyor-card {
+        font-size: 18px;
+        padding: 12px 18px;
       }
     }
   </style>
 </head>
 <body>
-  <div class="stats" id="stats">
-    <h3>Stats</h3>
-    <p><strong>Name:</strong> {{ student.first_name }}</p>
-    <p><strong>Time in Mode:</strong> <span id="time-in-mode">0</span> seconds</p>
-    <p><strong>Session Points:</strong> <span id="session-points">0</span></p>
-    <p><strong>Weekly Points:</strong> <span id="weekly-points">{{ student.weekly_points }}</span></p>
-    <p><strong>Total Points:</strong> <span id="total-points">{{ student.total_points }}</span></p>
-  </div>
-
-  <div class="pane">
-    <a href="{% url 'student_dashboard' %}" class="back-button">Back to Dashboard</a>
-    <h1>Peacock Conveyor Sorter</h1>
-    <p class="list-name">{{ vocab_list.name }} • {{ vocab_list.source_language|upper }} ➡ {{ vocab_list.target_language|upper }}</p>
-    <p class="instruction">Sort each word into the correct bin before it glides off the conveyor belt. Keep the Peacock happy!</p>
-
-    <div class="conveyor">
-      <div class="belt" id="belt">
-        <div class="card" id="moving-card">Ready?</div>
-      </div>
-    </div>
-
-    <div class="bin-grid">
-      <button class="bin" type="button" data-index="0"></button>
-      <button class="bin" type="button" data-index="1"></button>
-      <button class="bin" type="button" data-index="2"></button>
-      <button class="bin" type="button" data-index="3"></button>
-    </div>
-
-    <div class="status-bar">
+  <div class="game-shell">
+    <div class="info-panel">
+      <a href="{% url 'student_dashboard' %}" class="back-button">Back to Dashboard</a>
+      <h1>Peacock Feeding Frenzy</h1>
+      <p class="list-name">{{ vocab_list.name }} • {{ vocab_list.source_language|upper }} ➡ {{ vocab_list.target_language|upper }}</p>
+      <p class="instruction">Drag the correct translation from the moving conveyor belts into each hungry peacock before their timer wheel runs out! Each one you feed is worth 10 points.</p>
       <p id="feedback-message" class="feedback" role="status" aria-live="polite"></p>
       <div class="summary">
-        <span>Sorted: <strong id="sorted-count">0</strong></span>
-        <span>Remaining: <strong id="remaining-count">0</strong></span>
+        <span>Points Earned: <strong id="points-earned">0</strong></span>
+        <span>Fed: <strong id="fed-count">0</strong></span>
+        <span>Longest Streak: <strong id="streak-count">0</strong></span>
       </div>
       <button id="play-again-btn" class="btn play-again" type="button" hidden>Play Again</button>
+    </div>
+
+    <div class="board-panel">
+      <div class="game-stage" id="game-stage">
+        <div class="conveyor-area" id="conveyors"></div>
+        <div class="peacock-runway" id="peacock-runway"></div>
+      </div>
+    </div>
+
+    <div class="start-overlay" id="start-overlay">
+      <div class="start-card">
+        <h2>Ready to Feed the Peacocks?</h2>
+        <p>Drag each translation to the matching peacock before their timer expires.</p>
+        <button id="start-button" class="btn" type="button">Start</button>
+        <div id="countdown-display" class="countdown-display" hidden>3</div>
+      </div>
+    </div>
+
+    <div class="game-over-panel" id="game-over-panel" hidden>
+      <div class="game-over-card">
+        <h2>Game Over</h2>
+        <p id="game-over-reason"></p>
+        <p>You fed <strong id="final-fed-count">0</strong> peacocks.</p>
+        <p>Total points earned: <strong id="final-points-earned">0</strong></p>
+        <p>Best streak: <strong id="final-streak-count">0</strong></p>
+        <button id="game-over-restart" class="btn" type="button">Play Again</button>
+      </div>
+    </div>
+
+    <div class="empty-state" id="empty-state" hidden>
+      No words are ready for this mini-game yet. Add more vocabulary to start feeding the peacocks!
     </div>
   </div>
 
@@ -340,214 +640,744 @@
     const words = JSON.parse(`{{ words_json|default:'[]'|safe }}`);
     const progressUrl = "{% url 'update_progress' %}";
     const pointsUrl = "{% url 'update_points' %}";
-    const POINTS_PER_CORRECT = 1;
-    const ROUND_DURATION = 8000;
-    const TICK_RATE = 40;
+    const peacockImageUrl = "{% static 'pavonify_bird.png' %}";
 
-    const belt = document.getElementById("belt");
-    const card = document.getElementById("moving-card");
-    const bins = Array.from(document.querySelectorAll(".bin"));
+    const POINTS_PER_CORRECT = 10;
+    const INITIAL_PEACOCK_INTERVAL = 5600;
+    const MIN_PEACOCK_INTERVAL = 3000;
+    const INTERVAL_RAMP = 0.96;
+    const CARD_SPAWN_INTERVAL = 1400;
+    const CARD_MIN_GAP = 1400;
+    const MAX_ACTIVE_CARDS = 9;
+    const MAX_TRACK_CARDS = 3;
+    const TIMER_TICK = 120;
+    const BASE_MIN_LIFETIME = 5000;
+    const BASE_MAX_LIFETIME = 10000;
+    const LIFETIME_DECAY_INTERVAL = 30000;
+    const MAX_LIFETIME_REDUCTION = 3200;
+
+    const conveyorsContainer = document.getElementById("conveyors");
+    const runway = document.getElementById("peacock-runway");
     const feedbackMessage = document.getElementById("feedback-message");
-    const sortedCountEl = document.getElementById("sorted-count");
-    const remainingCountEl = document.getElementById("remaining-count");
+    const fedCountEl = document.getElementById("fed-count");
+    const streakCountEl = document.getElementById("streak-count");
+    const pointsEarnedEl = document.getElementById("points-earned");
     const playAgainBtn = document.getElementById("play-again-btn");
+    const gameOverPanel = document.getElementById("game-over-panel");
+    const gameOverReason = document.getElementById("game-over-reason");
+    const finalFedCount = document.getElementById("final-fed-count");
+    const finalStreakCount = document.getElementById("final-streak-count");
+    const finalPointsEarned = document.getElementById("final-points-earned");
+    const restartButtons = [playAgainBtn, document.getElementById("game-over-restart")];
+    const emptyState = document.getElementById("empty-state");
+    const startOverlay = document.getElementById("start-overlay");
+    const startButton = document.getElementById("start-button");
+    const countdownDisplay = document.getElementById("countdown-display");
 
-    const sessionPointsEl = document.getElementById("session-points");
-    const weeklyPointsEl = document.getElementById("weekly-points");
-    const totalPointsEl = document.getElementById("total-points");
-    const timeInModeEl = document.getElementById("time-in-mode");
+    let activePeacocks = new Map();
+    let peacockTimer = null;
+    let cardSpawner = null;
+    let peacockSpawner = null;
+    let countdownTimer = null;
+    let countdownTimeout = null;
+    let nextPeacockId = 0;
+    let spawnInterval = INITIAL_PEACOCK_INTERVAL;
+    let trackStates = [];
+    let wordDeck = [];
+    let gameRunning = false;
+    let fedCount = 0;
+    let streak = 0;
+    let longestStreak = 0;
+    let pointsEarned = 0;
+    let draggedCard = null;
+    let gameStartTime = 0;
+    let peacocksSpawned = 0;
+    let initialPeacockTimeouts = [];
 
-    let sessionPoints = 0;
-    let weeklyPoints = parseInt(weeklyPointsEl.textContent, 10) || 0;
-    let totalPoints = parseInt(totalPointsEl.textContent, 10) || 0;
-    let timeInMode = 0;
-    let sortedCount = 0;
-    let remaining = words.length;
-    let queue = shuffle([...words]);
-    let currentWord = null;
-    let moveInterval = null;
-    let isLocked = false;
+    restartButtons.forEach((button) => {
+      if (!button) return;
+      button.addEventListener("click", () => {
+        if (!words.length) {
+          return;
+        }
+        beginCountdown();
+      });
+    });
 
-    remainingCountEl.textContent = remaining;
-
-    const timer = setInterval(() => {
-      timeInMode += 1;
-      timeInModeEl.textContent = timeInMode;
-    }, 1000);
-
-    bins.forEach((bin) => bin.addEventListener("click", handleBinClick));
-    playAgainBtn.addEventListener("click", resetGame);
+    if (startButton) {
+      startButton.addEventListener("click", () => {
+        if (!words.length) {
+          return;
+        }
+        beginCountdown();
+      });
+    }
 
     if (!words.length) {
       showNoWordsState();
     } else {
-      startRound();
+      buildConveyors();
+      showStartPrompt();
     }
 
     function showNoWordsState() {
-      feedbackMessage.textContent = "No words available for this mini-game yet.";
-      feedbackMessage.style.color = "var(--peacock-warning)";
-      card.textContent = "Add more words to play!";
-      card.style.transform = "translate(-200px, -50%)";
-      bins.forEach((bin) => {
-        bin.textContent = "—";
-        bin.disabled = true;
-      });
-      playAgainBtn.hidden = true;
-    }
-
-    function resetGame() {
-      queue = shuffle([...words]);
-      sortedCount = 0;
-      remaining = words.length;
-      sortedCountEl.textContent = sortedCount;
-      remainingCountEl.textContent = remaining;
-      playAgainBtn.hidden = true;
+      emptyState.hidden = false;
       feedbackMessage.textContent = "";
-      feedbackMessage.style.color = "var(--peacock-primary)";
-      startRound();
+      playAgainBtn.hidden = true;
+      conveyorsContainer.innerHTML = "";
+      runway.innerHTML = "";
+      clearCountdown();
+      if (startOverlay) {
+        startOverlay.hidden = true;
+      }
     }
 
-    function startRound() {
-      clearInterval(moveInterval);
-      card.classList.remove("success", "fail");
+    function buildConveyors() {
+      conveyorsContainer.innerHTML = "";
+      trackStates = [];
+      for (let i = 0; i < 3; i += 1) {
+        const conveyor = document.createElement("div");
+        conveyor.className = "conveyor";
 
-      if (!queue.length) {
-        showCompletion();
+        const track = document.createElement("div");
+        track.className = "conveyor-track";
+        track.dataset.direction = i === 1 ? "rtl" : "ltr";
+        conveyor.appendChild(track);
+        conveyorsContainer.appendChild(conveyor);
+
+        trackStates.push({
+          element: track,
+          lastSpawnTime: 0,
+          cardCount: 0,
+          index: i,
+          direction: i === 1 ? "rtl" : "ltr",
+        });
+      }
+    }
+
+    function clearCountdown() {
+      if (countdownTimer) {
+        clearInterval(countdownTimer);
+        countdownTimer = null;
+      }
+      if (countdownTimeout) {
+        clearTimeout(countdownTimeout);
+        countdownTimeout = null;
+      }
+    }
+
+    function showStartPrompt() {
+      if (!startOverlay) {
+        return;
+      }
+      if (!words.length) {
+        startOverlay.hidden = true;
+        return;
+      }
+      clearCountdown();
+      startOverlay.hidden = false;
+      if (startButton) {
+        startButton.hidden = false;
+        startButton.disabled = false;
+      }
+      if (countdownDisplay) {
+        countdownDisplay.hidden = true;
+      }
+      if (!gameRunning) {
+        feedbackMessage.textContent = "Click Start to begin the feeding frenzy!";
+        feedbackMessage.classList.remove("success", "warning");
+      }
+    }
+
+    function beginCountdown() {
+      if (!words.length) {
         return;
       }
 
-      currentWord = queue.shift();
-      setBinOptions(currentWord);
-
-      bins.forEach((bin) => {
-        bin.disabled = false;
-        bin.classList.remove("correct", "incorrect");
-      });
-
-      feedbackMessage.textContent = "";
-      feedbackMessage.style.color = "var(--peacock-primary)";
-      card.textContent = currentWord.word;
-      isLocked = false;
-      kickOffMovement();
-    }
-
-    function showCompletion() {
-      card.textContent = "All Sorted!";
-      card.style.transform = "translate(0, -50%)";
-      card.classList.add("success");
-      bins.forEach((bin) => {
-        bin.disabled = true;
-        bin.textContent = "🎉";
-      });
-      feedbackMessage.textContent = "Amazing work! The conveyor is clear.";
-      feedbackMessage.style.color = "var(--peacock-highlight)";
-      playAgainBtn.hidden = false;
-    }
-
-    function setBinOptions(word) {
-      const options = [word];
-      const pool = shuffle(words.filter((item) => item.id !== word.id));
-
-      while (options.length < Math.min(4, words.length) && pool.length) {
-        options.push(pool.shift());
-      }
-
-      while (options.length < bins.length && options.length) {
-        options.push(options[Math.floor(Math.random() * options.length)]);
-      }
-
-      const shuffled = shuffle(options).slice(0, bins.length);
-      bins.forEach((bin, index) => {
-        const option = shuffled[index] || word;
-        bin.textContent = option.translation;
-        bin.dataset.correct = option.id === word.id ? "1" : "0";
-      });
-    }
-
-    function handleBinClick(event) {
-      if (isLocked || !currentWord) {
+      if (!startOverlay || !countdownDisplay) {
+        startGame();
         return;
       }
 
-      isLocked = true;
-      clearInterval(moveInterval);
-      const bin = event.currentTarget;
-      const isCorrect = bin.dataset.correct === "1";
-
-      bins.forEach((button) => (button.disabled = true));
-      bin.classList.add(isCorrect ? "correct" : "incorrect");
-      card.classList.add(isCorrect ? "success" : "fail");
-
-      feedbackMessage.textContent = isCorrect
-        ? `Sorted! ${currentWord.word} ➡ ${currentWord.translation}`
-        : `Oops! ${currentWord.word} = ${currentWord.translation}`;
-      feedbackMessage.style.color = isCorrect ? "var(--peacock-highlight)" : "var(--peacock-warning)";
-
-      submitResult(isCorrect).finally(() => {
-        if (isCorrect) {
-          sortedCount += 1;
-          remaining = Math.max(remaining - 1, 0);
-          sortedCountEl.textContent = sortedCount;
-          remainingCountEl.textContent = remaining;
-        } else {
-          queue.push(currentWord);
-        }
-
-        setTimeout(() => {
-          startRound();
-        }, 900);
-      });
-    }
-
-    function handleMiss() {
-      if (isLocked || !currentWord) {
-        return;
+      clearCountdown();
+      startOverlay.hidden = false;
+      if (startButton) {
+        startButton.hidden = true;
+        startButton.disabled = true;
       }
+      countdownDisplay.hidden = false;
 
-      isLocked = true;
-      bins.forEach((button) => (button.disabled = true));
-      card.classList.add("fail");
-      feedbackMessage.textContent = `Missed! ${currentWord.word} = ${currentWord.translation}`;
-      feedbackMessage.style.color = "var(--peacock-warning)";
-
-      submitResult(false).finally(() => {
-        queue.push(currentWord);
-        setTimeout(() => {
-          startRound();
-        }, 1200);
-      });
-    }
-
-    function kickOffMovement() {
-      const beltWidth = belt.clientWidth;
-      const cardWidth = card.offsetWidth;
-      const start = -cardWidth - 24;
-      const end = beltWidth + 24;
-      let progress = 0;
-
-      card.style.transform = `translate(${start}px, -50%)`;
-
-      moveInterval = setInterval(() => {
-        if (isLocked) {
-          clearInterval(moveInterval);
+      let count = 3;
+      countdownDisplay.textContent = String(count);
+      countdownTimer = setInterval(() => {
+        count -= 1;
+        if (count > 0) {
+          countdownDisplay.textContent = String(count);
           return;
         }
 
-        progress += TICK_RATE / ROUND_DURATION;
-        const clamped = Math.min(progress, 1);
-        const position = start + (end - start) * clamped;
-        card.style.transform = `translate(${position}px, -50%)`;
-
-        if (clamped >= 1) {
-          clearInterval(moveInterval);
-          handleMiss();
-        }
-      }, TICK_RATE);
+        clearInterval(countdownTimer);
+        countdownTimer = null;
+        countdownDisplay.textContent = "Go!";
+        countdownTimeout = setTimeout(() => {
+          if (countdownDisplay) {
+            countdownDisplay.hidden = true;
+          }
+          if (startButton) {
+            startButton.hidden = false;
+            startButton.disabled = false;
+          }
+          if (startOverlay) {
+            startOverlay.hidden = true;
+          }
+          startGame();
+          countdownTimeout = null;
+        }, 520);
+      }, 1000);
     }
 
-    async function submitResult(isCorrect) {
-      if (!currentWord) {
+    function startGame() {
+      if (!words.length) {
+        showNoWordsState();
+        return;
+      }
+
+      clearCountdown();
+      resetState();
+      gameRunning = true;
+      emptyState.hidden = true;
+      playAgainBtn.hidden = true;
+      gameOverPanel.hidden = true;
+      feedbackMessage.textContent = "Feed the peacocks as fast as you can!";
+      feedbackMessage.classList.remove("success", "warning");
+      if (startOverlay) {
+        startOverlay.hidden = true;
+      }
+
+      gameStartTime = Date.now();
+      peacocksSpawned = 0;
+      spawnInterval = INITIAL_PEACOCK_INTERVAL;
+      spawnInitialCards();
+      spawnInitialPeacocks();
+      scheduleNextPeacock(spawnInterval);
+
+      clearInterval(cardSpawner);
+      cardSpawner = setInterval(() => {
+        if (document.querySelectorAll('.conveyor-card').length < MAX_ACTIVE_CARDS) {
+          spawnConveyorCard();
+        }
+      }, CARD_SPAWN_INTERVAL);
+
+      clearInterval(peacockTimer);
+      peacockTimer = setInterval(updatePeacocks, TIMER_TICK);
+    }
+
+    function resetState() {
+      fedCount = 0;
+      streak = 0;
+      longestStreak = 0;
+      pointsEarned = 0;
+      fedCountEl.textContent = fedCount;
+      streakCountEl.textContent = longestStreak;
+      if (pointsEarnedEl) {
+        pointsEarnedEl.textContent = pointsEarned;
+      }
+      if (finalPointsEarned) {
+        finalPointsEarned.textContent = pointsEarned;
+      }
+      runway.innerHTML = "";
+      trackStates.forEach((state) => {
+        state.element.innerHTML = "";
+        state.cardCount = 0;
+        state.lastSpawnTime = 0;
+      });
+      activePeacocks.clear();
+      if (peacockSpawner) {
+        clearTimeout(peacockSpawner);
+      }
+      initialPeacockTimeouts.forEach((timeout) => clearTimeout(timeout));
+      initialPeacockTimeouts = [];
+      wordDeck = shuffle(words);
+      nextPeacockId = 0;
+    }
+
+    function scheduleNextPeacock(delay = spawnInterval) {
+      if (!gameRunning) {
+        return;
+      }
+
+      const jitteredDelay = Math.max(MIN_PEACOCK_INTERVAL, delay + randomInRange(-400, 400));
+      peacockSpawner = setTimeout(() => {
+        spawnPeacock();
+        spawnInterval = Math.max(MIN_PEACOCK_INTERVAL, spawnInterval * INTERVAL_RAMP);
+        scheduleNextPeacock(spawnInterval);
+      }, jitteredDelay);
+    }
+
+    function spawnInitialCards() {
+      const totalCards = Math.min(words.length, MAX_ACTIVE_CARDS);
+      if (!totalCards) {
+        return;
+      }
+
+      const trackCount = trackStates.length || 1;
+      const perTrack = Math.max(1, Math.ceil(totalCards / trackCount));
+      let spawned = 0;
+
+      trackStates.forEach((state) => {
+        for (let i = 0; i < perTrack && spawned < totalCards; i += 1) {
+          const progress = clamp((i + 1) / (perTrack + 1), 0.15, 0.85);
+          spawnConveyorCard(null, {
+            prefill: true,
+            prefillProgress: progress,
+            trackIndex: state.index,
+          });
+          spawned += 1;
+        }
+      });
+    }
+
+    function spawnInitialPeacocks() {
+      if (!gameRunning) {
+        return;
+      }
+
+      spawnPeacock();
+      const timeout = setTimeout(() => {
+        if (!gameRunning) {
+          return;
+        }
+        spawnPeacock();
+      }, 1200);
+      initialPeacockTimeouts.push(timeout);
+    }
+
+    function spawnPeacock() {
+      if (!gameRunning) {
+        return;
+      }
+
+      const word = drawWord();
+      if (!word) {
+        return;
+      }
+
+      const peacockId = `peacock-${nextPeacockId += 1}`;
+      const wrapper = document.createElement("div");
+      wrapper.className = "peacock";
+      wrapper.dataset.id = peacockId;
+      wrapper.dataset.wordId = word.id;
+
+      const spawnIndex = peacocksSpawned + 1;
+      const lifetime = calculatePeacockLifetime(spawnIndex);
+      peacocksSpawned = spawnIndex;
+
+      const timerRing = document.createElement("div");
+      timerRing.className = "timer-ring";
+
+      const timerNumber = document.createElement("span");
+      timerNumber.className = "timer-number";
+      timerNumber.textContent = Math.ceil(lifetime / 1000);
+      timerRing.appendChild(timerNumber);
+
+      const speechBubble = document.createElement("div");
+      speechBubble.className = "speech-bubble";
+      speechBubble.textContent = word.word;
+      speechBubble.setAttribute("role", "button");
+      speechBubble.dataset.peacockId = peacockId;
+
+      const body = document.createElement("div");
+      body.className = "peacock-body";
+      const img = document.createElement("img");
+      img.src = peacockImageUrl;
+      img.alt = "Peacock";
+      body.appendChild(img);
+
+      wrapper.appendChild(timerRing);
+      wrapper.appendChild(speechBubble);
+      wrapper.appendChild(body);
+
+      runway.appendChild(wrapper);
+
+      const expiresAt = Date.now() + lifetime;
+      const peacock = {
+        id: peacockId,
+        word,
+        element: wrapper,
+        speechBubble,
+        timerRing,
+        timerNumber,
+        expiresAt,
+        lifetime,
+        fed: false,
+      };
+
+      activePeacocks.set(peacockId, peacock);
+      attachDropHandlers(peacock);
+      spawnConveyorCard(word, { priority: true });
+    }
+
+    function attachDropHandlers(peacock) {
+      const bubble = peacock.speechBubble;
+      const container = peacock.element;
+      let hoverDepth = 0;
+
+      container.addEventListener("dragover", (event) => {
+        if (!gameRunning) {
+          return;
+        }
+        event.preventDefault();
+        event.dataTransfer.dropEffect = "move";
+      });
+
+      container.addEventListener("dragenter", (event) => {
+        if (!gameRunning) {
+          return;
+        }
+        event.preventDefault();
+        hoverDepth += 1;
+        bubble.classList.add("drop-hover");
+      });
+
+      container.addEventListener("dragleave", () => {
+        if (!gameRunning) {
+          return;
+        }
+        hoverDepth = Math.max(hoverDepth - 1, 0);
+        if (hoverDepth === 0) {
+          bubble.classList.remove("drop-hover");
+        }
+      });
+
+      container.addEventListener("drop", (event) => {
+        if (!gameRunning) {
+          return;
+        }
+        event.preventDefault();
+        hoverDepth = 0;
+        bubble.classList.remove("drop-hover");
+
+        const cardElement = draggedCard;
+        const droppedWordId = cardElement?.dataset.wordId || event.dataTransfer.getData("text/plain");
+        handleDrop(peacock, droppedWordId, cardElement);
+      });
+    }
+
+    function spawnConveyorCard(preferredWord = null, options = {}) {
+      if (!words.length || !trackStates.length) {
+        return;
+      }
+
+      const {
+        prefill = false,
+        prefillProgress = Math.random() * 0.7 + 0.15,
+        trackIndex = null,
+        priority = false,
+      } = options;
+
+      const word = preferredWord || drawWord();
+      if (!word) {
+        return;
+      }
+
+      const card = document.createElement("div");
+      card.className = "conveyor-card";
+      card.draggable = true;
+      card.dataset.wordId = word.id;
+      card.textContent = word.translation;
+
+      const duration = randomInRange(11500, 15000);
+      card.style.setProperty('--duration', `${duration}ms`);
+
+      let trackState = null;
+      if (Number.isInteger(trackIndex)) {
+        trackState = trackStates.find((state) => state.index === Number(trackIndex)) || null;
+      }
+
+      if (!trackState) {
+        const candidateStates = (!prefill && !priority)
+          ? trackStates.filter((state) => state.cardCount < MAX_TRACK_CARDS)
+          : trackStates;
+
+        if (candidateStates.length) {
+          trackState = candidateStates.reduce((best, state) => {
+            if (!best) {
+              return state;
+            }
+            if (state.cardCount < best.cardCount) {
+              return state;
+            }
+            if (state.cardCount === best.cardCount && state.lastSpawnTime < best.lastSpawnTime) {
+              return state;
+            }
+            return best;
+          }, null);
+        }
+      }
+
+      if (!trackState) {
+        return;
+      }
+
+      if (!prefill && !priority && trackState.cardCount >= MAX_TRACK_CARDS) {
+        return;
+      }
+
+      trackState.element.appendChild(card);
+      trackState.cardCount += 1;
+      card.dataset.trackIndex = String(trackState.index);
+      card.dataset.direction = trackState.direction;
+
+      if (trackState.direction === "rtl") {
+        card.classList.add("direction-rtl");
+      } else {
+        card.classList.add("direction-ltr");
+      }
+
+      const now = Date.now();
+      const timeSinceLast = now - trackState.lastSpawnTime;
+      let startDelay = 0;
+
+      if (!prefill) {
+        if (priority) {
+          const minPriorityGap = CARD_MIN_GAP * 0.6;
+          if (timeSinceLast < minPriorityGap) {
+            startDelay = minPriorityGap - timeSinceLast;
+          }
+        } else if (timeSinceLast < CARD_MIN_GAP) {
+          startDelay = CARD_MIN_GAP - timeSinceLast;
+        }
+      }
+
+      if (prefill) {
+        const clampedProgress = clamp(prefillProgress, 0, 0.92);
+        const offset = Math.floor(duration * clampedProgress);
+        card.style.animationDelay = `-${offset}ms`;
+        trackState.lastSpawnTime = now - Math.min(offset, CARD_MIN_GAP);
+      } else if (startDelay > 0) {
+        card.style.animationDelay = `${Math.floor(startDelay)}ms`;
+        trackState.lastSpawnTime = now + startDelay;
+      } else {
+        trackState.lastSpawnTime = now;
+      }
+
+      card.addEventListener("animationend", () => {
+        releaseCard(card);
+      });
+
+      card.addEventListener("dragstart", (event) => {
+        if (!gameRunning) {
+          event.preventDefault();
+          return;
+        }
+        draggedCard = card;
+        card.classList.add("dragging");
+        event.dataTransfer.effectAllowed = "move";
+        event.dataTransfer.setData("text/plain", String(word.id));
+      });
+
+      card.addEventListener("dragend", () => {
+        draggedCard = null;
+        card.classList.remove("dragging");
+      });
+    }
+
+    function releaseCard(card) {
+      if (!card) {
+        return;
+      }
+
+      const trackIndexValue = Number(card.dataset.trackIndex);
+      const trackState = Number.isInteger(trackIndexValue)
+        ? trackStates.find((state) => state.index === trackIndexValue)
+        : null;
+
+      if (trackState) {
+        trackState.cardCount = Math.max(0, trackState.cardCount - 1);
+      }
+
+      if (card.parentElement) {
+        card.parentElement.removeChild(card);
+      }
+    }
+
+    function handleDrop(peacock, droppedWordId, cardElement) {
+      if (!peacock || peacock.fed || !gameRunning) {
+        return;
+      }
+
+      if (String(peacock.word.id) === String(droppedWordId)) {
+        if (cardElement) {
+          releaseCard(cardElement);
+        }
+        feedPeacock(peacock);
+      } else {
+        if (cardElement) {
+          cardElement.classList.add("inactive");
+          setTimeout(() => cardElement.classList.remove("inactive"), 300);
+        }
+        peacock.speechBubble.classList.add("shake");
+        setTimeout(() => peacock.speechBubble.classList.remove("shake"), 360);
+        showFeedback(`Not quite! ${peacock.word.word} needs "${peacock.word.translation}".`, "warning");
+      }
+    }
+
+    function feedPeacock(peacock) {
+      if (!peacock || peacock.fed) {
+        return;
+      }
+
+      peacock.fed = true;
+      activePeacocks.delete(peacock.id);
+      peacock.element.classList.add("fed");
+
+      showFeedback(`Fed! ${peacock.word.word} ➡ ${peacock.word.translation}`, "success");
+
+      fedCount += 1;
+      streak += 1;
+      longestStreak = Math.max(longestStreak, streak);
+      fedCountEl.textContent = fedCount;
+      streakCountEl.textContent = longestStreak;
+      pointsEarned += POINTS_PER_CORRECT;
+      if (pointsEarnedEl) {
+        pointsEarnedEl.textContent = pointsEarned;
+      }
+
+      submitResult(peacock.word, true);
+
+      setTimeout(() => {
+        peacock.element.remove();
+      }, 420);
+    }
+
+    function updatePeacocks() {
+      if (!gameRunning) {
+        return;
+      }
+
+      const now = Date.now();
+      activePeacocks.forEach((peacock) => {
+        const remaining = peacock.expiresAt - now;
+        const totalLifetime = peacock.lifetime || BASE_MAX_LIFETIME;
+        if (remaining <= 0) {
+          activePeacocks.delete(peacock.id);
+          triggerGameOver(peacock);
+          return;
+        }
+
+        const ratio = Math.max(remaining / totalLifetime, 0);
+        const degrees = Math.max(0, Math.min(360, ratio * 360));
+        const color = ratio > 0.45 ? 'var(--peacock-highlight)' : ratio > 0.2 ? '#ffba08' : 'var(--peacock-warning)';
+        peacock.timerRing.style.background = `conic-gradient(${color} ${degrees}deg, rgba(0, 0, 0, 0.08) ${degrees}deg)`;
+        peacock.timerRing.classList.toggle("urgent", remaining <= 3000);
+        peacock.timerNumber.textContent = Math.ceil(Math.max(remaining, 0) / 1000);
+      });
+    }
+
+    function triggerGameOver(peacock) {
+      if (!gameRunning) {
+        return;
+      }
+
+      gameRunning = false;
+      streak = 0;
+
+      if (peacock && peacock.element) {
+        peacock.element.classList.add("shake");
+        setTimeout(() => peacock.element.remove(), 500);
+        submitResult(peacock.word, false);
+      }
+
+      showFeedback("Oh no! A peacock went hungry.", "warning");
+      finalizeGame("A peacock flew away before getting the right word.");
+    }
+
+    function finalizeGame(reason) {
+      clearInterval(cardSpawner);
+      clearInterval(peacockTimer);
+      if (peacockSpawner) {
+        clearTimeout(peacockSpawner);
+      }
+
+      document.querySelectorAll('.conveyor-card').forEach((card) => {
+        card.classList.add("inactive");
+      });
+
+      finalFedCount.textContent = fedCount;
+      finalStreakCount.textContent = longestStreak;
+      if (finalPointsEarned) {
+        finalPointsEarned.textContent = pointsEarned;
+      }
+      gameOverReason.textContent = reason;
+      gameOverPanel.hidden = false;
+      playAgainBtn.hidden = false;
+    }
+
+    function drawWord() {
+      if (!words.length) {
+        return null;
+      }
+      if (!wordDeck.length) {
+        wordDeck = shuffle(words);
+      }
+      return wordDeck.shift();
+    }
+
+    function shuffle(items) {
+      const arr = [...items];
+      for (let i = arr.length - 1; i > 0; i -= 1) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [arr[i], arr[j]] = [arr[j], arr[i]];
+      }
+      return arr;
+    }
+
+    function calculatePeacockLifetime(spawnIndex) {
+      if (spawnIndex <= 2) {
+        return BASE_MAX_LIFETIME;
+      }
+
+      const elapsed = Math.max(Date.now() - gameStartTime, 0);
+      const timeFactor = clamp(elapsed / (LIFETIME_DECAY_INTERVAL * 4), 0, 1);
+      const spawnFactor = clamp((spawnIndex - 2) / 12, 0, 1);
+      const blendedDifficulty = clamp((timeFactor * 0.6) + (spawnFactor * 0.4), 0, 1);
+
+      const maxLifetime = BASE_MAX_LIFETIME - Math.floor(MAX_LIFETIME_REDUCTION * blendedDifficulty);
+      let minLifetime = BASE_MIN_LIFETIME + Math.floor((MAX_LIFETIME_REDUCTION * 0.45) * blendedDifficulty);
+      let adjustedMax = Math.max(maxLifetime, BASE_MIN_LIFETIME + 800);
+
+      if (minLifetime >= adjustedMax - 400) {
+        minLifetime = adjustedMax - 400;
+      }
+
+      minLifetime = clamp(minLifetime, BASE_MIN_LIFETIME, BASE_MAX_LIFETIME - 500);
+      adjustedMax = clamp(adjustedMax, minLifetime + 400, BASE_MAX_LIFETIME);
+
+      let lifetime = randomInRange(minLifetime, adjustedMax);
+      const hungerSwing = randomInRange(-350, 450);
+      lifetime = clamp(lifetime + hungerSwing, BASE_MIN_LIFETIME, BASE_MAX_LIFETIME);
+
+      return lifetime;
+    }
+
+    function clamp(value, min, max) {
+      return Math.min(Math.max(value, min), max);
+    }
+
+    function randomInRange(min, max) {
+      return Math.floor(Math.random() * (max - min + 1)) + min;
+    }
+
+    function showFeedback(message, type = "") {
+      feedbackMessage.textContent = message;
+      feedbackMessage.classList.remove("success", "warning");
+      if (type) {
+        feedbackMessage.classList.add(type);
+      }
+    }
+
+    async function submitResult(word, isCorrect) {
+      if (!word) {
         return;
       }
 
@@ -559,7 +1389,7 @@
             "X-CSRFToken": getCSRFToken(),
           },
           body: JSON.stringify({
-            word_id: currentWord.id,
+            word_id: word.id,
             correct: isCorrect,
           }),
         });
@@ -582,32 +1412,12 @@
         }
 
         const data = await response.json();
-        if (data.success) {
-          if (isCorrect) {
-            sessionPoints += POINTS_PER_CORRECT;
-            sessionPointsEl.textContent = sessionPoints;
-          }
-          weeklyPoints = data.weekly_points;
-          totalPoints = data.total_points;
-          weeklyPointsEl.textContent = weeklyPoints;
-          totalPointsEl.textContent = totalPoints;
-
-          if (Array.isArray(data.new_trophies) && data.new_trophies.length) {
-            alert("New trophies: " + data.new_trophies.join(", "));
-          }
+        if (data.success && Array.isArray(data.new_trophies) && data.new_trophies.length) {
+          alert("New trophies: " + data.new_trophies.join(", "));
         }
       } catch (error) {
         console.error("Error updating points:", error);
       }
-    }
-
-    function shuffle(items) {
-      const arr = [...items];
-      for (let i = arr.length - 1; i > 0; i--) {
-        const j = Math.floor(Math.random() * (i + 1));
-        [arr[i], arr[j]] = [arr[j], arr[i]];
-      }
-      return arr;
     }
 
     function getCSRFToken() {


### PR DESCRIPTION
## Summary
- reshape the mini-game layout into a side-by-side info panel and board with a start overlay and countdown so the session stays in one viewport.【F:learning/templates/learning/mini_game_1.html†L592-L620】
- prefill conveyor belts with alternating directions, per-track caps, and hover-friendly drop zones across each peacock to keep cards spaced instead of overlapping.【F:learning/templates/learning/mini_game_1.html†L208-L216】【F:learning/templates/learning/mini_game_1.html†L735-L938】【F:learning/templates/learning/mini_game_1.html†L1020-L1159】
- adjust spawn pacing by opening with two peacocks, jittering future spawns toward shorter intervals, and keeping lifetime difficulty scaling between five and ten seconds.【F:learning/templates/learning/mini_game_1.html†L904-L953】【F:learning/templates/learning/mini_game_1.html†L1335-L1360】
- add an inline 10-point scoring counter plus a red pulse when timers drop under three seconds to make urgency and rewards clear.【F:learning/templates/learning/mini_game_1.html†L597-L603】【F:learning/templates/learning/mini_game_1.html†L645-L670】【F:learning/templates/learning/mini_game_1.html†L1236-L1310】【F:learning/templates/learning/mini_game_1.html†L286-L299】【F:learning/templates/learning/mini_game_1.html†L1270-L1273】

## Testing
- python manage.py check【217154†L1】

------
https://chatgpt.com/codex/tasks/task_e_68ca727a81c48325b9c053a315269596