### PR TITLE
Integrate energy meter and mini-game into practice flows

### DIFF
--- a/frontend/src/gamehub/EnergyMeter.js
+++ b/frontend/src/gamehub/EnergyMeter.js
@@ -1,0 +1,34 @@
+import React from "react";
+import { useGameHub } from "./GameHubContext.js";
+
+export default function EnergyMeter({ onLaunch }) {
+  const { energy, tokens, maxTokens } = useGameHub();
+  const pct = Math.min(100, energy);
+  const canLaunch = tokens > 0;
+  const meter = React.createElement(
+    'div',
+    { className: 'relative w-36 h-5 bg-sky-100 rounded-full overflow-hidden' },
+    React.createElement('div', {
+      className: 'h-full bg-sky-400 transition-all',
+      style: { width: `${pct}%` },
+    }),
+    React.createElement(
+      'div',
+      { className: 'absolute inset-0 flex items-center justify-center text-xs font-semibold' },
+      `${pct}% Energy`
+    )
+  );
+
+  const button = React.createElement(
+    'button',
+    {
+      'aria-label': 'Mini-game launcher',
+      className: `px-3 py-1 rounded-xl shadow ${canLaunch ? 'bg-emerald-500 text-white hover:scale-105' : 'bg-gray-200 text-gray-500'}`,
+      disabled: !canLaunch,
+      onClick: onLaunch,
+    },
+    `🎮 x${tokens}/${maxTokens}`
+  );
+
+  return React.createElement('div', { className: 'flex items-center gap-3' }, meter, button);
+}

--- a/frontend/src/gamehub/EnergyMeter.tsx
+++ b/frontend/src/gamehub/EnergyMeter.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { useGameHub } from "./GameHubContext";
+
+type Props = {
+  onLaunch: () => void;
+};
+
+export default function EnergyMeter({ onLaunch }: Props) {
+  const { energy, tokens, maxTokens } = useGameHub();
+  const pct = Math.min(100, energy);
+  const canLaunch = tokens > 0;
+
+  return (
+    <div className="flex items-center gap-3">
+      <div className="relative w-36 h-5 bg-sky-100 rounded-full overflow-hidden">
+        <div className="h-full bg-sky-400 transition-all" style={{ width: `${pct}%` }} />
+        <div className="absolute inset-0 flex items-center justify-center text-xs font-semibold">
+          {pct}% Energy
+        </div>
+      </div>
+      <button
+        aria-label="Mini-game launcher"
+        className={`px-3 py-1 rounded-xl shadow ${canLaunch ? "bg-emerald-500 text-white hover:scale-105" : "bg-gray-200 text-gray-500"}`}
+        disabled={!canLaunch}
+        onClick={onLaunch}
+      >
+        🎮 x{tokens}/{maxTokens}
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/gamehub/GameHubContext.js
+++ b/frontend/src/gamehub/GameHubContext.js
@@ -1,0 +1,82 @@
+import React, { createContext, useContext, useEffect, useMemo, useState } from "react";
+
+const GameHubContext = createContext(null);
+
+export const useGameHub = () => {
+  const ctx = useContext(GameHubContext);
+  if (!ctx) {
+    throw new Error("GameHubContext missing");
+  }
+  return ctx;
+};
+
+const KEY = "pavonify_gamehub_v1";
+
+export function GameHubProvider({ children }) {
+  const [energy, setEnergy] = useState(0);
+  const [tokens, setTokens] = useState(0);
+  const [maxTokens] = useState(3);
+
+  useEffect(() => {
+    const raw = localStorage.getItem(KEY);
+    if (!raw) {
+      return;
+    }
+    try {
+      const value = JSON.parse(raw);
+      setEnergy(Number.isFinite(value?.energy) ? value.energy : 0);
+      setTokens(Number.isFinite(value?.tokens) ? value.tokens : 0);
+    } catch (error) {
+      console.warn("Failed to parse game hub state", error);
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem(KEY, JSON.stringify({ energy, tokens }));
+  }, [energy, tokens]);
+
+  function gainEnergy(base, streak) {
+    const bonus = streak >= 20 ? 2 : streak >= 10 ? 1 : 0;
+    let next = energy + base + bonus;
+    let newTokens = tokens;
+
+    while (next >= 100 && newTokens < maxTokens) {
+      next -= 100;
+      newTokens += 1;
+    }
+
+    if (newTokens >= maxTokens) {
+      next = Math.min(next, 99);
+    }
+
+    setEnergy(Math.round(next));
+    setTokens(newTokens);
+  }
+
+  function consumeToken() {
+    if (tokens <= 0) {
+      return false;
+    }
+    setTokens(prev => Math.max(prev - 1, 0));
+    return true;
+  }
+
+  function resetEnergy() {
+    setEnergy(0);
+  }
+
+  const value = useMemo(
+    () => ({
+      energy,
+      tokens,
+      maxTokens,
+      gainEnergy,
+      consumeToken,
+      resetEnergy,
+      setEnergy,
+    }),
+    [energy, tokens, maxTokens]
+  );
+
+  return React.createElement(GameHubContext.Provider, { value }, children);
+}

--- a/frontend/src/gamehub/GameHubContext.tsx
+++ b/frontend/src/gamehub/GameHubContext.tsx
@@ -1,0 +1,86 @@
+import React, { createContext, useContext, useEffect, useMemo, useState } from "react";
+
+export type HubState = {
+  energy: number;
+  tokens: number;
+  maxTokens: number;
+  gainEnergy: (base: number, streak: number) => void;
+  consumeToken: () => boolean;
+  resetEnergy: () => void;
+  setEnergy: (n: number) => void;
+};
+
+const GameHubContext = createContext<HubState | null>(null);
+
+export const useGameHub = () => {
+  const ctx = useContext(GameHubContext);
+  if (!ctx) throw new Error("GameHubContext missing");
+  return ctx;
+};
+
+const KEY = "pavonify_gamehub_v1";
+
+export function GameHubProvider({ children }: { children: React.ReactNode }) {
+  const [energy, setEnergy] = useState(0);
+  const [tokens, setTokens] = useState(0);
+  const [maxTokens] = useState(3);
+
+  useEffect(() => {
+    const raw = localStorage.getItem(KEY);
+    if (raw) {
+      try {
+        const v = JSON.parse(raw) as { energy?: unknown; tokens?: unknown };
+        const storedEnergy = typeof v.energy === "number" && Number.isFinite(v.energy) ? v.energy : 0;
+        const storedTokens = typeof v.tokens === "number" && Number.isFinite(v.tokens) ? v.tokens : 0;
+        setEnergy(storedEnergy);
+        setTokens(storedTokens);
+      } catch (error) {
+        console.warn("Failed to restore game hub state", error);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem(KEY, JSON.stringify({ energy, tokens }));
+  }, [energy, tokens]);
+
+  function gainEnergy(base: number, streak: number) {
+    const bonus = streak >= 20 ? 2 : streak >= 10 ? 1 : 0;
+    let next = energy + base + bonus;
+    let newTokens = tokens;
+
+    while (next >= 100 && newTokens < maxTokens) {
+      next -= 100;
+      newTokens += 1;
+    }
+
+    if (newTokens >= maxTokens) next = Math.min(next, 99);
+    setEnergy(Math.round(next));
+    setTokens(newTokens);
+  }
+
+  function consumeToken() {
+    if (tokens <= 0) return false;
+    setTokens(prev => Math.max(prev - 1, 0));
+    return true;
+  }
+
+  function resetEnergy() {
+    setEnergy(0);
+  }
+
+  const value = useMemo(
+    () => ({
+      energy,
+      tokens,
+      maxTokens,
+      gainEnergy,
+      consumeToken,
+      resetEnergy,
+      setEnergy,
+    }),
+    [energy, tokens, maxTokens]
+  );
+
+  return <GameHubContext.Provider value={value}>{children}</GameHubContext.Provider>;
+}

--- a/frontend/src/gamehub/GameLauncherModal.js
+++ b/frontend/src/gamehub/GameLauncherModal.js
@@ -1,0 +1,69 @@
+import React, { useEffect, useState } from "react";
+import { useGameHub } from "./GameHubContext.js";
+import PeacockConveyorSorter from "../games/PeacockConveyorSorter.js";
+
+export default function GameLauncherModal({
+  open,
+  onClose,
+  mode,
+  fetchWords,
+  postResult,
+  awardSession,
+}) {
+  const { consumeToken } = useGameHub();
+  const [words, setWords] = useState(null);
+  const [startedAt, setStartedAt] = useState(null);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    if (!consumeToken()) {
+      onClose();
+      return;
+    }
+    fetchWords(mode)
+      .then(setWords)
+      .catch(() => setWords([]));
+    setStartedAt(Date.now());
+  }, [open, consumeToken, fetchWords, mode, onClose]);
+
+  if (!open) {
+    return null;
+  }
+
+  const content = !words
+    ? React.createElement('div', { className: 'p-10 text-center' }, 'Loading words…')
+    : React.createElement(PeacockConveyorSorter, {
+        words,
+        timeLimitMs: 90000,
+        onComplete: async summary => {
+          const payload = {
+            gameKey: 'peacock-conveyor',
+            ...summary,
+            startedAt,
+            endedAt: Date.now(),
+            mode,
+          };
+          try {
+            await postResult(payload);
+            const points = summary.score;
+            const streakDelta = summary.accuracy >= 0.9 && summary.correct >= 15 ? 5 : 0;
+            await awardSession({
+              pointsDelta: points,
+              streakDelta,
+              energyDelta: 0,
+              tokensDelta: 0,
+            });
+          } finally {
+            onClose();
+          }
+        },
+      });
+
+  return React.createElement(
+    'div',
+    { className: 'fixed inset-0 bg-black/40 flex items-center justify-center z-50' },
+    React.createElement('div', { className: 'bg-white rounded-3xl shadow-2xl p-4 w-full max-w-3xl' }, content)
+  );
+}

--- a/frontend/src/gamehub/GameLauncherModal.tsx
+++ b/frontend/src/gamehub/GameLauncherModal.tsx
@@ -1,0 +1,85 @@
+import React, { useEffect, useState } from "react";
+import { useGameHub } from "./GameHubContext";
+import PeacockConveyorSorter, { GameWord } from "@/games/PeacockConveyorSorter";
+
+type Mode = "practice" | "assignment";
+
+type AwardBody = {
+  pointsDelta: number;
+  streakDelta: number;
+  energyDelta: number;
+  tokensDelta: number;
+};
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  mode: Mode;
+  fetchWords: (mode: Mode) => Promise<GameWord[]>;
+  postResult: (body: unknown) => Promise<void>;
+  awardSession: (body: AwardBody) => Promise<void>;
+};
+
+export default function GameLauncherModal({
+  open,
+  onClose,
+  mode,
+  fetchWords,
+  postResult,
+  awardSession,
+}: Props) {
+  const { consumeToken } = useGameHub();
+  const [words, setWords] = useState<GameWord[] | null>(null);
+  const [startedAt, setStartedAt] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    if (!consumeToken()) {
+      onClose();
+      return;
+    }
+    fetchWords(mode)
+      .then(setWords)
+      .catch(() => setWords([]));
+    setStartedAt(Date.now());
+  }, [open, consumeToken, fetchWords, mode, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+      <div className="bg-white rounded-3xl shadow-2xl p-4 w-full max-w-3xl">
+        {!words ? (
+          <div className="p-10 text-center">Loading words…</div>
+        ) : (
+          <PeacockConveyorSorter
+            words={words}
+            timeLimitMs={90000}
+            onComplete={async summary => {
+              const payload = {
+                gameKey: "peacock-conveyor",
+                ...summary,
+                startedAt,
+                endedAt: Date.now(),
+                mode,
+              };
+              try {
+                await postResult(payload);
+                const points = summary.score;
+                const streakDelta = summary.accuracy >= 0.9 && summary.correct >= 15 ? 5 : 0;
+                await awardSession({
+                  pointsDelta: points,
+                  streakDelta,
+                  energyDelta: 0,
+                  tokensDelta: 0,
+                });
+              } finally {
+                onClose();
+              }
+            }}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/gamehub/useEnergyMeter.js
+++ b/frontend/src/gamehub/useEnergyMeter.js
@@ -1,0 +1,13 @@
+import { useGameHub } from "./GameHubContext.js";
+
+export function useEnergyMeter() {
+  const hub = useGameHub();
+
+  function onQuestionResult({ correct, streak }) {
+    if (correct) {
+      hub.gainEnergy(1, streak);
+    }
+  }
+
+  return { ...hub, onQuestionResult };
+}

--- a/frontend/src/gamehub/useEnergyMeter.ts
+++ b/frontend/src/gamehub/useEnergyMeter.ts
@@ -1,0 +1,16 @@
+import { useGameHub } from "./GameHubContext";
+
+type QuestionResult = {
+  correct: boolean;
+  streak: number;
+};
+
+export function useEnergyMeter() {
+  const hub = useGameHub();
+
+  function onQuestionResult({ correct, streak }: QuestionResult) {
+    if (correct) hub.gainEnergy(1, streak);
+  }
+
+  return { ...hub, onQuestionResult };
+}

--- a/frontend/src/games/PeacockConveyorSorter.js
+++ b/frontend/src/games/PeacockConveyorSorter.js
@@ -1,0 +1,183 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+function toSummary(entries, startedAt) {
+  const correct = entries.filter(item => item.correct).length;
+  const wrong = entries.length - correct;
+  const total = entries.length;
+  const accuracy = total > 0 ? correct / total : 0;
+  const timeMs = Date.now() - startedAt;
+
+  return {
+    score: correct * 10,
+    accuracy,
+    correct,
+    wrong,
+    wordsSeen: entries.map(item => item.word),
+    timeMs,
+  };
+}
+
+export default function PeacockConveyorSorter({ words, timeLimitMs = 60000, onComplete }) {
+  const [index, setIndex] = useState(0);
+  const [results, setResults] = useState([]);
+  const [timeLeft, setTimeLeft] = useState(timeLimitMs);
+  const completedRef = useRef(false);
+  const startRef = useRef(Date.now());
+  const resultsRef = useRef([]);
+
+  const safeWords = useMemo(() => (Array.isArray(words) ? words : []), [words]);
+  const currentWord = safeWords[index] ?? null;
+
+  useEffect(() => {
+    resultsRef.current = results;
+  }, [results]);
+
+  const finishGame = useCallback(
+    entries => {
+      if (completedRef.current) {
+        return;
+      }
+      const finalEntries = entries ?? resultsRef.current;
+      completedRef.current = true;
+      onComplete(toSummary(finalEntries, startRef.current));
+    },
+    [onComplete]
+  );
+
+  useEffect(() => {
+    completedRef.current = false;
+    startRef.current = Date.now();
+    setResults([]);
+    setIndex(0);
+    setTimeLeft(timeLimitMs);
+  }, [safeWords, timeLimitMs]);
+
+  useEffect(() => {
+    if (safeWords.length === 0 && !completedRef.current) {
+      finishGame([]);
+      return;
+    }
+    const update = () => {
+      const elapsed = Date.now() - startRef.current;
+      const remaining = Math.max(timeLimitMs - elapsed, 0);
+      setTimeLeft(remaining);
+      if (remaining <= 0) {
+        finishGame();
+      }
+    };
+    update();
+    const interval = window.setInterval(update, 250);
+    return () => window.clearInterval(interval);
+  }, [finishGame, safeWords.length, timeLimitMs]);
+
+  const markResult = useCallback(
+    isCorrect => {
+      if (!currentWord || completedRef.current) {
+        return;
+      }
+      const entry = { word: currentWord, correct: isCorrect };
+      setResults(prev => {
+        const next = [...prev, entry];
+        if (next.length >= safeWords.length) {
+          window.setTimeout(() => finishGame(next), 0);
+        }
+        return next;
+      });
+      setIndex(prev => {
+        const nextIndex = prev + 1;
+        if (nextIndex >= safeWords.length) {
+          return 0;
+        }
+        return nextIndex;
+      });
+    },
+    [currentWord, finishGame, safeWords.length]
+  );
+
+  const correctCount = useMemo(() => results.filter(item => item.correct).length, [results]);
+  const wrongCount = results.length - correctCount;
+  const secondsLeft = Math.ceil(timeLeft / 1000);
+
+  const header = React.createElement(
+    'div',
+    { className: 'flex flex-wrap items-center justify-between gap-4 rounded-xl border border-slate-200 bg-slate-50 p-4' },
+    React.createElement(
+      'div',
+      null,
+      React.createElement('p', { className: 'text-sm font-semibold text-slate-700' }, 'Time Left'),
+      React.createElement('p', { className: 'text-2xl font-bold text-slate-900' }, `${Math.max(secondsLeft, 0)}s`)
+    ),
+    React.createElement(
+      'div',
+      { className: 'flex gap-6' },
+      React.createElement(
+        'div',
+        { className: 'text-center' },
+        React.createElement('p', { className: 'text-xs uppercase tracking-wide text-slate-500' }, 'Fed'),
+        React.createElement('p', { className: 'text-lg font-semibold text-emerald-600' }, correctCount)
+      ),
+      React.createElement(
+        'div',
+        { className: 'text-center' },
+        React.createElement('p', { className: 'text-xs uppercase tracking-wide text-slate-500' }, 'Missed'),
+        React.createElement('p', { className: 'text-lg font-semibold text-rose-500' }, wrongCount)
+      )
+    )
+  );
+
+  const wordContent = currentWord
+    ? React.createElement(
+        'div',
+        { className: 'flex flex-col items-center gap-4' },
+        React.createElement('p', { className: 'text-sm uppercase tracking-wide text-slate-500' }, 'Feed this word'),
+        React.createElement('p', { className: 'text-2xl font-bold text-slate-900' }, currentWord.prompt ?? ''),
+        currentWord.answer
+          ? React.createElement(
+              'p',
+              { className: 'text-base text-slate-500' },
+              `Target: ${currentWord.answer}`
+            )
+          : null,
+        React.createElement(
+          'div',
+          { className: 'mt-4 flex w-full max-w-md flex-col gap-3 sm:flex-row' },
+          React.createElement(
+            'button',
+            {
+              type: 'button',
+              onClick: () => markResult(true),
+              className: 'flex-1 rounded-lg bg-emerald-500 px-4 py-2 text-white shadow hover:bg-emerald-600',
+            },
+            'Fed Correctly'
+          ),
+          React.createElement(
+            'button',
+            {
+              type: 'button',
+              onClick: () => markResult(false),
+              className: 'flex-1 rounded-lg bg-rose-500 px-4 py-2 text-white shadow hover:bg-rose-600',
+            },
+            'Missed'
+          )
+        )
+      )
+    : React.createElement('div', { className: 'text-center text-sm text-slate-500' }, 'No words available.');
+
+  const board = React.createElement(
+    'div',
+    { className: 'rounded-2xl border border-slate-200 bg-white p-6 shadow' },
+    wordContent
+  );
+
+  const finishButton = React.createElement(
+    'button',
+    {
+      type: 'button',
+      onClick: () => finishGame(),
+      className: 'self-center rounded-lg border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-600 hover:bg-slate-100',
+    },
+    'Finish Early'
+  );
+
+  return React.createElement('div', { className: 'flex flex-col gap-4' }, header, board, finishButton);
+}

--- a/frontend/src/games/PeacockConveyorSorter.tsx
+++ b/frontend/src/games/PeacockConveyorSorter.tsx
@@ -1,0 +1,184 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+export type GameWord = {
+  id?: string | number;
+  prompt?: string;
+  answer?: string;
+  [key: string]: unknown;
+};
+
+export type MiniGameSummary = {
+  score: number;
+  accuracy: number;
+  correct: number;
+  wrong: number;
+  wordsSeen: GameWord[];
+  timeMs: number;
+};
+
+type MiniGameProps = {
+  words: GameWord[];
+  timeLimitMs?: number;
+  onComplete: (summary: MiniGameSummary) => void;
+};
+
+type ResultEntry = {
+  word: GameWord;
+  correct: boolean;
+};
+
+function toSummary(entries: ResultEntry[], startedAt: number): MiniGameSummary {
+  const correct = entries.filter(item => item.correct).length;
+  const wrong = entries.length - correct;
+  const total = entries.length;
+  const accuracy = total > 0 ? correct / total : 0;
+  const timeMs = Date.now() - startedAt;
+
+  return {
+    score: correct * 10,
+    accuracy,
+    correct,
+    wrong,
+    wordsSeen: entries.map(item => item.word),
+    timeMs,
+  };
+}
+
+const PeacockConveyorSorter: React.FC<MiniGameProps> = ({ words, timeLimitMs = 60000, onComplete }) => {
+  const [index, setIndex] = useState(0);
+  const [results, setResults] = useState<ResultEntry[]>([]);
+  const [timeLeft, setTimeLeft] = useState(timeLimitMs);
+  const completedRef = useRef(false);
+  const startRef = useRef(Date.now());
+  const resultsRef = useRef<ResultEntry[]>([]);
+
+  const safeWords = useMemo(() => (Array.isArray(words) ? words : []), [words]);
+  const currentWord = safeWords[index] ?? null;
+
+  useEffect(() => {
+    resultsRef.current = results;
+  }, [results]);
+
+  const finishGame = useCallback(
+    (entries?: ResultEntry[]) => {
+      if (completedRef.current) return;
+      const finalEntries = entries ?? resultsRef.current;
+      completedRef.current = true;
+      onComplete(toSummary(finalEntries, startRef.current));
+    },
+    [onComplete]
+  );
+
+  useEffect(() => {
+    completedRef.current = false;
+    startRef.current = Date.now();
+    setResults([]);
+    setIndex(0);
+    setTimeLeft(timeLimitMs);
+  }, [safeWords, timeLimitMs]);
+
+  useEffect(() => {
+    if (safeWords.length === 0 && !completedRef.current) {
+      finishGame([]);
+      return;
+    }
+    const update = () => {
+      const elapsed = Date.now() - startRef.current;
+      const remaining = Math.max((timeLimitMs ?? 60000) - elapsed, 0);
+      setTimeLeft(remaining);
+      if (remaining <= 0) {
+        finishGame();
+      }
+    };
+    update();
+    const interval = window.setInterval(update, 250);
+    return () => window.clearInterval(interval);
+  }, [finishGame, safeWords.length, timeLimitMs]);
+
+  const markResult = useCallback(
+    (isCorrect: boolean) => {
+      if (!currentWord || completedRef.current) return;
+      const entry: ResultEntry = { word: currentWord, correct: isCorrect };
+      setResults(prev => {
+        const next = [...prev, entry];
+        if (next.length >= safeWords.length) {
+          window.setTimeout(() => finishGame(next), 0);
+        }
+        return next;
+      });
+      setIndex(prev => {
+        const nextIndex = prev + 1;
+        if (nextIndex >= safeWords.length) {
+          return 0;
+        }
+        return nextIndex;
+      });
+    },
+    [currentWord, finishGame, safeWords.length]
+  );
+
+  const correctCount = useMemo(() => results.filter(item => item.correct).length, [results]);
+  const wrongCount = results.length - correctCount;
+  const secondsLeft = Math.ceil(timeLeft / 1000);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-center justify-between gap-4 rounded-xl border border-slate-200 bg-slate-50 p-4">
+        <div>
+          <p className="text-sm font-semibold text-slate-700">Time Left</p>
+          <p className="text-2xl font-bold text-slate-900">{Math.max(secondsLeft, 0)}s</p>
+        </div>
+        <div className="flex gap-6">
+          <div className="text-center">
+            <p className="text-xs uppercase tracking-wide text-slate-500">Fed</p>
+            <p className="text-lg font-semibold text-emerald-600">{correctCount}</p>
+          </div>
+          <div className="text-center">
+            <p className="text-xs uppercase tracking-wide text-slate-500">Missed</p>
+            <p className="text-lg font-semibold text-rose-500">{wrongCount}</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow">
+        {currentWord ? (
+          <div className="flex flex-col items-center gap-4">
+            <p className="text-sm uppercase tracking-wide text-slate-500">Feed this word</p>
+            <p className="text-2xl font-bold text-slate-900">{currentWord.prompt ?? ""}</p>
+            {currentWord.answer ? (
+              <p className="text-base text-slate-500">Target: {currentWord.answer}</p>
+            ) : null}
+            <div className="mt-4 flex w-full max-w-md flex-col gap-3 sm:flex-row">
+              <button
+                type="button"
+                onClick={() => markResult(true)}
+                className="flex-1 rounded-lg bg-emerald-500 px-4 py-2 text-white shadow hover:bg-emerald-600"
+              >
+                Fed Correctly
+              </button>
+              <button
+                type="button"
+                onClick={() => markResult(false)}
+                className="flex-1 rounded-lg bg-rose-500 px-4 py-2 text-white shadow hover:bg-rose-600"
+              >
+                Missed
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div className="text-center text-sm text-slate-500">No words available.</div>
+        )}
+      </div>
+
+      <button
+        type="button"
+        onClick={() => finishGame()}
+        className="self-center rounded-lg border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-600 hover:bg-slate-100"
+      >
+        Finish Early
+      </button>
+    </div>
+  );
+};
+
+export default PeacockConveyorSorter;

--- a/learning/templates/learning/assignment_practice_session.html
+++ b/learning/templates/learning/assignment_practice_session.html
@@ -52,11 +52,27 @@
             position: relative;
         }
         .header {
-            text-align: center;
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: space-between;
+            align-items: center;
+            gap: 16px;
+            text-align: left;
         }
         .header h1 {
             margin: 0;
             font-size: 28px;
+        }
+        .title-block {
+            flex: 1 1 auto;
+        }
+        .title-block p {
+            margin: 6px 0 0;
+        }
+        .energy-meter-container {
+            display: flex;
+            justify-content: flex-end;
+            min-width: 160px;
         }
         #activity-container {
             margin-top: 30px;
@@ -262,8 +278,11 @@
 <div class="pane">
     <button class="back-button btn" onclick="window.history.back()">Back</button>
     <div class="header">
-        <h1>Assignment: {{ assignment.name }}</h1>
-        <p><strong>Assignment Points:</strong> <span id="assignment-points">{{ current_points }}</span> / {{ total_points }}</p>
+        <div class="title-block">
+            <h1>Assignment: {{ assignment.name }}</h1>
+            <p><strong>Assignment Points:</strong> <span id="assignment-points">{{ current_points }}</span> / {{ total_points }}</p>
+        </div>
+        <div class="energy-meter-container" id="energy-meter-container"></div>
     </div>
     <p><strong>Session Points:</strong> <span id="session-points">0</span></p>
     <div id="streak-container"><div id="streak-bar"></div></div>
@@ -272,12 +291,18 @@
     <div id="activity-container"></div>
 </div>
 <div id="accent-panel" class="accent-panel"></div>
+<script src="{% static 'js/gamehub.js' %}"></script>
+<script src="{% static 'js/mini_game_launcher.js' %}"></script>
 <script>
     document.addEventListener('DOMContentLoaded', () => {
         fetchActivity();
         initAccentKeyboard();
+        setupEnergyMeter();
+        refreshStreakUI();
     });
 
+    const MINI_GAME_MODE = 'assignment';
+    const ENERGY_BASE_PER_CORRECT = 2;
     let sessionPoints = 0;
     let assignmentPoints = {{ current_points }};
     const totalAssignmentPoints = {{ total_points }};
@@ -432,6 +457,106 @@
         gain.gain.exponentialRampToValueAtTime(0.00001, ctx.currentTime + 0.5);
         osc.start();
         osc.stop(ctx.currentTime + 0.5);
+    }
+
+    function setupEnergyMeter() {
+        if (!window.GameHub || typeof window.GameHub.renderEnergyMeter !== 'function') {
+            return;
+        }
+        const container = document.getElementById('energy-meter-container');
+        if (!container) {
+            return;
+        }
+        window.GameHub.renderEnergyMeter(container, {
+            onLaunch: () => launchMiniGame()
+        });
+    }
+
+    function launchMiniGame() {
+        if (!window.MiniGameLauncher || typeof window.MiniGameLauncher.open !== 'function') {
+            return;
+        }
+        window.MiniGameLauncher.open({
+            mode: MINI_GAME_MODE,
+            fetchWords: fetchMiniGameWords,
+            postResult: postMiniGameResult,
+            awardSession: awardMiniGameSession,
+            onSessionAward: award => applySessionAward(award)
+        });
+    }
+
+    async function fetchMiniGameWords(mode) {
+        const response = await fetch(`/api/srs/current-words?mode=${encodeURIComponent(mode)}`, {
+            credentials: 'include'
+        });
+        if (!response.ok) {
+            throw new Error('Failed to load current words');
+        }
+        const data = await response.json();
+        if (!Array.isArray(data)) {
+            throw new Error('Invalid words payload');
+        }
+        return data;
+    }
+
+    async function postMiniGameResult(body) {
+        const response = await fetch('/api/srs/game-result', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRFToken': getCookie('csrftoken')
+            },
+            credentials: 'include',
+            body: JSON.stringify(body)
+        });
+        if (!response.ok) {
+            throw new Error('Failed to record game result');
+        }
+    }
+
+    async function awardMiniGameSession(body) {
+        const response = await fetch('/api/srs/session-award', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRFToken': getCookie('csrftoken')
+            },
+            credentials: 'include',
+            body: JSON.stringify(body)
+        });
+        if (!response.ok) {
+            throw new Error('Failed to apply session awards');
+        }
+        const pointsDelta = Number(body && body.pointsDelta) || 0;
+        if (pointsDelta) {
+            const assignmentResponse = await fetch("{% url 'update_assignment_points' %}", {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRFToken': getCookie('csrftoken')
+                },
+                credentials: 'include',
+                body: JSON.stringify({ assignment_id: {{ assignment.id }}, points: pointsDelta })
+            });
+            if (!assignmentResponse.ok) {
+                throw new Error('Failed to update assignment points');
+            }
+        }
+    }
+
+    function applySessionAward(award) {
+        const pointsDelta = Number(award && award.pointsDelta) || 0;
+        if (pointsDelta) {
+            sessionPoints += pointsDelta;
+            assignmentPoints += pointsDelta;
+            document.getElementById('session-points').textContent = sessionPoints;
+            document.getElementById('assignment-points').textContent = Math.min(assignmentPoints, totalAssignmentPoints);
+        }
+        const streakDelta = Number(award && award.streakDelta) || 0;
+        if (streakDelta) {
+            globalStreak = Math.max(globalStreak + streakDelta, 0);
+            refreshStreakUI();
+        }
     }
 
     function initAccentKeyboard() {
@@ -729,53 +854,50 @@
         });
     }
 
-    function updateStreak(correct, count=true) {
-        if (count) {
-            if (correct) {
-                globalStreak += 1;
-            } else {
-                globalStreak = 0;
-            }
+    function computeMultiplierFromStreak(streak) {
+        if (streak >= 185) return 5;
+        if (streak >= 85) return 4;
+        if (streak >= 35) return 3;
+        if (streak >= 10) return 2;
+        return 1;
+    }
 
-            if (globalStreak >= 185) {
-                multiplier = 5;
-            } else if (globalStreak >= 85) {
-                multiplier = 4;
-            } else if (globalStreak >= 35) {
-                multiplier = 3;
-            } else if (globalStreak >= 10) {
-                multiplier = 2;
-            } else {
-                multiplier = 1;
-            }
-            if (assignmentPoints >= totalAssignmentPoints && multiplier < 2) {
-                multiplier = 2;
-            }
+    function refreshStreakUI() {
+        let newMultiplier = computeMultiplierFromStreak(globalStreak);
+        if (assignmentPoints >= totalAssignmentPoints && newMultiplier < 2) {
+            newMultiplier = 2;
         }
-
-        if (multiplier > prevMultiplier) {
+        if (newMultiplier > prevMultiplier) {
             playChirp('multiplier');
         }
-        prevMultiplier = multiplier;
+        multiplier = newMultiplier;
+        prevMultiplier = newMultiplier;
 
         document.getElementById('streak-count').textContent = globalStreak;
         document.getElementById('multiplier').textContent = multiplier;
 
-        let prev = 0;
-        let next = streakThresholds[1];
+        let prev = streakThresholds[0];
+        let next = streakThresholds[1] ?? streakThresholds[0] + 1;
         for (let i = 1; i < streakThresholds.length; i++) {
             if (globalStreak < streakThresholds[i]) {
                 next = streakThresholds[i];
-                prev = streakThresholds[i-1];
                 break;
             }
             prev = streakThresholds[i];
-            next = streakThresholds[i+1] || streakThresholds[i];
+            next = streakThresholds[i + 1] || streakThresholds[i];
         }
-        const percent = Math.min(((globalStreak - prev) / (next - prev)) * 100, 100);
+        const range = Math.max(next - prev, 1);
+        const percent = Math.min(((globalStreak - prev) / range) * 100, 100);
         const bar = document.getElementById('streak-bar');
         bar.style.width = percent + '%';
         bar.style.background = multiplierColors[multiplier];
+    }
+
+    function updateStreak(correct, count=true) {
+        if (count) {
+            globalStreak = correct ? globalStreak + 1 : 0;
+        }
+        refreshStreakUI();
     }
 
     function showFeedback(correct, correctAnswer=null) {
@@ -799,10 +921,14 @@
 
             if (count && correct) {
                 assignmentPoints += 5 * multiplier;
-                document.getElementById('assignment-points').textContent = assignmentPoints;
+                document.getElementById('assignment-points').textContent = Math.min(assignmentPoints, totalAssignmentPoints);
             }
 
             updateStreak(correct, count);
+
+            if (count && correct && window.GameHub && typeof window.GameHub.gainEnergy === 'function') {
+                window.GameHub.gainEnergy(ENERGY_BASE_PER_CORRECT, globalStreak);
+            }
 
             if (count && correct) {
                 sessionPoints += 5 * multiplier;

--- a/learning/templates/learning/practice_session.html
+++ b/learning/templates/learning/practice_session.html
@@ -52,11 +52,24 @@
             position: relative;
         }
         .header {
-            text-align: center;
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: space-between;
+            align-items: center;
+            gap: 16px;
+            text-align: left;
         }
         .header h1 {
             margin: 0;
             font-size: 28px;
+        }
+        .title-block {
+            flex: 1 1 auto;
+        }
+        .energy-meter-container {
+            display: flex;
+            justify-content: flex-end;
+            min-width: 160px;
         }
         #activity-container {
             margin-top: 30px;
@@ -262,7 +275,10 @@
 <div class="pane">
     <button class="back-button btn" onclick="window.history.back()">Back</button>
     <div class="header">
-        <h1>Practice Session - {{ vocab_list.name }}</h1>
+        <div class="title-block">
+            <h1>Practice Session - {{ vocab_list.name }}</h1>
+        </div>
+        <div class="energy-meter-container" id="energy-meter-container"></div>
     </div>
     <p><strong>Session Points:</strong> <span id="session-points">0</span></p>
     <div id="streak-container"><div id="streak-bar"></div></div>
@@ -271,12 +287,18 @@
     <div id="activity-container"></div>
 </div>
 <div id="accent-panel" class="accent-panel"></div>
+<script src="{% static 'js/gamehub.js' %}"></script>
+<script src="{% static 'js/mini_game_launcher.js' %}"></script>
 <script>
     document.addEventListener('DOMContentLoaded', () => {
         fetchActivity();
         initAccentKeyboard();
+        setupEnergyMeter();
+        refreshStreakUI();
     });
 
+    const MINI_GAME_MODE = 'practice';
+    const ENERGY_BASE_PER_CORRECT = 1;
     let sessionPoints = 0;
     let globalStreak = 0;
     let multiplier = 1;
@@ -429,6 +451,89 @@
         gain.gain.exponentialRampToValueAtTime(0.00001, ctx.currentTime + 0.5);
         osc.start();
         osc.stop(ctx.currentTime + 0.5);
+    }
+
+    function setupEnergyMeter() {
+        if (!window.GameHub || typeof window.GameHub.renderEnergyMeter !== 'function') {
+            return;
+        }
+        const container = document.getElementById('energy-meter-container');
+        if (!container) {
+            return;
+        }
+        window.GameHub.renderEnergyMeter(container, {
+            onLaunch: () => launchMiniGame()
+        });
+    }
+
+    function launchMiniGame() {
+        if (!window.MiniGameLauncher || typeof window.MiniGameLauncher.open !== 'function') {
+            return;
+        }
+        window.MiniGameLauncher.open({
+            mode: MINI_GAME_MODE,
+            fetchWords: fetchMiniGameWords,
+            postResult: postMiniGameResult,
+            awardSession: awardMiniGameSession,
+            onSessionAward: award => applySessionAward(award)
+        });
+    }
+
+    async function fetchMiniGameWords(mode) {
+        const response = await fetch(`/api/srs/current-words?mode=${encodeURIComponent(mode)}`, {
+            credentials: 'include'
+        });
+        if (!response.ok) {
+            throw new Error('Failed to load current words');
+        }
+        const data = await response.json();
+        if (!Array.isArray(data)) {
+            throw new Error('Invalid words payload');
+        }
+        return data;
+    }
+
+    async function postMiniGameResult(body) {
+        const response = await fetch('/api/srs/game-result', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRFToken': getCookie('csrftoken')
+            },
+            credentials: 'include',
+            body: JSON.stringify(body)
+        });
+        if (!response.ok) {
+            throw new Error('Failed to record game result');
+        }
+    }
+
+    async function awardMiniGameSession(body) {
+        const response = await fetch('/api/srs/session-award', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRFToken': getCookie('csrftoken')
+            },
+            credentials: 'include',
+            body: JSON.stringify(body)
+        });
+        if (!response.ok) {
+            throw new Error('Failed to apply session awards');
+        }
+    }
+
+    function applySessionAward(award) {
+        const pointsDelta = Number(award && award.pointsDelta) || 0;
+        if (pointsDelta) {
+            sessionPoints += pointsDelta;
+            document.getElementById('session-points').textContent = sessionPoints;
+        }
+        const streakDelta = Number(award && award.streakDelta) || 0;
+        if (streakDelta) {
+            globalStreak = Math.max(globalStreak + streakDelta, 0);
+            refreshStreakUI();
+        }
     }
 
     function initAccentKeyboard() {
@@ -726,50 +831,47 @@
         });
     }
 
-    function updateStreak(correct, count=true) {
-        if (count) {
-            if (correct) {
-                globalStreak += 1;
-            } else {
-                globalStreak = 0;
-            }
+    function computeMultiplierFromStreak(streak) {
+        if (streak >= 185) return 5;
+        if (streak >= 85) return 4;
+        if (streak >= 35) return 3;
+        if (streak >= 10) return 2;
+        return 1;
+    }
 
-            if (globalStreak >= 185) {
-                multiplier = 5;
-            } else if (globalStreak >= 85) {
-                multiplier = 4;
-            } else if (globalStreak >= 35) {
-                multiplier = 3;
-            } else if (globalStreak >= 10) {
-                multiplier = 2;
-            } else {
-                multiplier = 1;
-            }
-        }
-
-        if (multiplier > prevMultiplier) {
+    function refreshStreakUI() {
+        const newMultiplier = computeMultiplierFromStreak(globalStreak);
+        if (newMultiplier > prevMultiplier) {
             playChirp('multiplier');
         }
-        prevMultiplier = multiplier;
+        multiplier = newMultiplier;
+        prevMultiplier = newMultiplier;
 
         document.getElementById('streak-count').textContent = globalStreak;
         document.getElementById('multiplier').textContent = multiplier;
 
-        let prev = 0;
-        let next = streakThresholds[1];
+        let prev = streakThresholds[0];
+        let next = streakThresholds[1] ?? streakThresholds[0] + 1;
         for (let i = 1; i < streakThresholds.length; i++) {
             if (globalStreak < streakThresholds[i]) {
                 next = streakThresholds[i];
-                prev = streakThresholds[i-1];
                 break;
             }
             prev = streakThresholds[i];
-            next = streakThresholds[i+1] || streakThresholds[i];
+            next = streakThresholds[i + 1] || streakThresholds[i];
         }
-        const percent = Math.min(((globalStreak - prev) / (next - prev)) * 100, 100);
+        const range = Math.max(next - prev, 1);
+        const percent = Math.min(((globalStreak - prev) / range) * 100, 100);
         const bar = document.getElementById('streak-bar');
         bar.style.width = percent + '%';
         bar.style.background = multiplierColors[multiplier];
+    }
+
+    function updateStreak(correct, count=true) {
+        if (count) {
+            globalStreak = correct ? globalStreak + 1 : 0;
+        }
+        refreshStreakUI();
     }
 
     function showFeedback(correct, correctAnswer=null) {
@@ -792,6 +894,10 @@
             });
 
             updateStreak(correct, count);
+
+            if (count && correct && window.GameHub && typeof window.GameHub.gainEnergy === 'function') {
+                window.GameHub.gainEnergy(ENERGY_BASE_PER_CORRECT, globalStreak);
+            }
 
             if (count && correct) {
                 sessionPoints += 5 * multiplier;

--- a/srs/frontend/ReviewSession.js
+++ b/srs/frontend/ReviewSession.js
@@ -1,80 +1,235 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import ExposureCard from './cards/ExposureCard.js';
 import TappingCard from './cards/TappingCard.js';
 import MCQCard from './cards/MCQCard.js';
 import TypingCard from './cards/TypingCard.js';
 import ListeningCard from './cards/ListeningCard.js';
+import { GameHubProvider } from '../../frontend/src/gamehub/GameHubContext.js';
+import { useEnergyMeter } from '../../frontend/src/gamehub/useEnergyMeter.js';
+import EnergyMeter from '../../frontend/src/gamehub/EnergyMeter.js';
+import GameLauncherModal from '../../frontend/src/gamehub/GameLauncherModal.js';
+
+const PRACTICE_MODE = 'practice';
 
 function getCookie(name) {
   const value = `; ${document.cookie}`;
   const parts = value.split(`; ${name}=`);
-  if (parts.length === 2) return parts.pop().split(';').shift();
+  if (parts.length === 2) {
+    const segment = parts.pop();
+    if (segment) {
+      return segment.split(';').shift() ?? null;
+    }
+  }
+  return null;
 }
 
-export default function ReviewSession({ fetchImpl = fetch }) {
+function ReviewSessionInner({ fetchImpl = fetch }) {
   const fetchFn = fetchImpl;
   const [queue, setQueue] = useState([]);
   const [current, setCurrent] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [launcherOpen, setLauncherOpen] = useState(false);
+  const [sessionPoints, setSessionPoints] = useState(0);
+  const [streak, setStreak] = useState(0);
+  const { onQuestionResult } = useEnergyMeter();
 
-  useEffect(() => {
-    fetchFn('/api/srs/queue?limit=30&mode=mix', { credentials: 'include' })
-      .then(r => r.json())
-      .then(setQueue);
+  const jsonHeaders = useCallback(() => {
+    const headers = { 'Content-Type': 'application/json' };
+    const csrftoken = getCookie('csrftoken');
+    if (csrftoken) {
+      headers['X-CSRFToken'] = csrftoken;
+    }
+    return headers;
   }, []);
 
+  const loadQueue = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetchFn('/api/srs/queue?limit=30&mode=mix', { credentials: 'include' });
+      const data = await response.json();
+      const items = Array.isArray(data) ? data : [];
+      setQueue(items);
+      setCurrent(items[0] ?? null);
+    } catch (err) {
+      console.error('Failed to load SRS queue', err);
+      setError('Unable to load practice queue.');
+      setQueue([]);
+      setCurrent(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [fetchFn]);
+
   useEffect(() => {
-    setCurrent(queue[0]);
+    loadQueue();
+  }, [loadQueue]);
+
+  useEffect(() => {
+    if (queue.length > 0) {
+      setCurrent(queue[0]);
+    } else {
+      setCurrent(null);
+    }
   }, [queue]);
 
-  function handleResult(is_correct, extra = {}) {
-    if (!current) return Promise.resolve();
-    const payload = {
-      word_id: current.word_id,
-      activity_type: current.suggested_next_activity,
-      is_correct,
-      ...extra
-    };
-    const remaining = queue.slice(1);
-    setQueue(remaining);
-    setCurrent(remaining[0] || null);
-
-    const csrftoken = getCookie('csrftoken');
-    const headers = { 'Content-Type': 'application/json' };
-    if (csrftoken) headers['X-CSRFToken'] = csrftoken;
-
-    return fetchFn('/api/srs/attempt', {
-      method: 'POST',
-      headers,
-      body: JSON.stringify(payload),
-      credentials: 'include'
-    }).then(() => {
-      if (remaining.length === 0) {
-        return fetchFn('/api/srs/queue?limit=30&mode=mix', { credentials: 'include' })
-          .then(r => r.json())
-          .then(setQueue);
+  const handleResult = useCallback(
+    async (correct, extra = {}) => {
+      if (!current) {
+        return;
       }
-    });
-  }
 
-  if (!current) {
-    return React.createElement('div', null, 'Loading');
-  }
+      const payload = {
+        word_id: current.word_id,
+        activity_type: current.suggested_next_activity,
+        is_correct: correct,
+        ...extra,
+      };
 
-  const props = {
-    word: current,
-    onSubmit: (correct, extra) => handleResult(correct, extra)
-  };
+      const remaining = queue.slice(1);
+      setQueue(remaining);
+      setCurrent(remaining[0] ?? null);
 
-  switch (current.suggested_next_activity) {
-    case 'tapping':
-      return React.createElement(TappingCard, props);
-    case 'mcq':
-      return React.createElement(MCQCard, props);
-    case 'typing':
-      return React.createElement(TypingCard, props);
-    case 'listening':
-      return React.createElement(ListeningCard, props);
-    default:
-      return React.createElement(ExposureCard, props);
-  }
+      const nextStreakValue = correct ? streak + 1 : 0;
+      setStreak(nextStreakValue);
+      onQuestionResult({ correct, streak: nextStreakValue });
+
+      if (correct) {
+        setSessionPoints(prev => prev + 10);
+      }
+
+      try {
+        await fetchFn('/api/srs/attempt', {
+          method: 'POST',
+          headers: jsonHeaders(),
+          credentials: 'include',
+          body: JSON.stringify(payload),
+        });
+      } catch (err) {
+        console.error('Failed to submit attempt', err);
+      } finally {
+        if (remaining.length === 0) {
+          await loadQueue();
+        }
+      }
+    },
+    [current, fetchFn, jsonHeaders, loadQueue, onQuestionResult, queue, streak]
+  );
+
+  const card = useMemo(() => {
+    if (!current) {
+      return null;
+    }
+    const props = { word: current, onSubmit: handleResult };
+    switch (current.suggested_next_activity) {
+      case 'tapping':
+        return React.createElement(TappingCard, props);
+      case 'mcq':
+        return React.createElement(MCQCard, props);
+      case 'typing':
+        return React.createElement(TypingCard, props);
+      case 'listening':
+        return React.createElement(ListeningCard, props);
+      default:
+        return React.createElement(ExposureCard, props);
+    }
+  }, [current, handleResult]);
+
+  const fetchWords = useCallback(
+    async mode => {
+      const response = await fetchFn(`/api/srs/current-words?mode=${mode}`, {
+        credentials: 'include',
+      });
+      if (!response.ok) {
+        throw new Error('Failed to load current words');
+      }
+      const data = await response.json();
+      if (!Array.isArray(data)) {
+        throw new Error('Invalid words payload');
+      }
+      return data;
+    },
+    [fetchFn]
+  );
+
+  const postResult = useCallback(
+    async body => {
+      const response = await fetchFn('/api/srs/game-result', {
+        method: 'POST',
+        headers: jsonHeaders(),
+        credentials: 'include',
+        body: JSON.stringify(body),
+      });
+      if (!response.ok) {
+        throw new Error('Failed to record game result');
+      }
+    },
+    [fetchFn, jsonHeaders]
+  );
+
+  const awardSession = useCallback(
+    async body => {
+      const response = await fetchFn('/api/srs/session-award', {
+        method: 'POST',
+        headers: jsonHeaders(),
+        credentials: 'include',
+        body: JSON.stringify(body),
+      });
+      if (!response.ok) {
+        throw new Error('Failed to apply session awards');
+      }
+      setSessionPoints(prev => prev + (body.pointsDelta ?? 0));
+      if (body.streakDelta) {
+        setStreak(prev => Math.max(prev + body.streakDelta, 0));
+      }
+    },
+    [fetchFn, jsonHeaders]
+  );
+
+  const header = React.createElement(
+    'div',
+    { className: 'flex flex-wrap items-center justify-between gap-4 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm' },
+    React.createElement(
+      'div',
+      null,
+      React.createElement('h2', { className: 'text-lg font-semibold text-slate-900' }, 'Practice Session'),
+      React.createElement('p', { className: 'text-sm text-slate-500' }, `Session Points: ${sessionPoints}`),
+      React.createElement('p', { className: 'text-sm text-slate-500' }, `Current Streak: ${streak}`)
+    ),
+    React.createElement(EnergyMeter, { onLaunch: () => setLauncherOpen(true) })
+  );
+
+  const errorBlock = error
+    ? React.createElement('div', { className: 'rounded-lg bg-red-50 p-4 text-sm text-red-600' }, error)
+    : null;
+
+  const content = loading
+    ? React.createElement('div', { className: 'text-center text-sm text-slate-500' }, 'Loading…')
+    : card || React.createElement('div', { className: 'text-center text-sm text-slate-500' }, 'All done for now! 🎉');
+
+  const board = React.createElement(
+    'div',
+    { className: 'min-h-[200px] rounded-2xl border border-slate-200 bg-white p-6 shadow-sm' },
+    content
+  );
+
+  const modal = React.createElement(GameLauncherModal, {
+    open: launcherOpen,
+    onClose: () => setLauncherOpen(false),
+    mode: PRACTICE_MODE,
+    fetchWords,
+    postResult,
+    awardSession,
+  });
+
+  return React.createElement('div', { className: 'flex flex-col gap-4 p-4' }, header, errorBlock, board, modal);
+}
+
+export default function ReviewSession(props) {
+  return React.createElement(
+    GameHubProvider,
+    null,
+    React.createElement(ReviewSessionInner, props)
+  );
 }

--- a/srs/frontend/ReviewSession.tsx
+++ b/srs/frontend/ReviewSession.tsx
@@ -1,0 +1,233 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import ExposureCard from "./cards/ExposureCard";
+import TappingCard from "./cards/TappingCard";
+import MCQCard from "./cards/MCQCard";
+import TypingCard from "./cards/TypingCard";
+import ListeningCard from "./cards/ListeningCard";
+import { CardProps, CardSubmitExtra, ReviewWord } from "./types";
+import { GameHubProvider } from "@/gamehub/GameHubContext";
+import { useEnergyMeter } from "@/gamehub/useEnergyMeter";
+import EnergyMeter from "@/gamehub/EnergyMeter";
+import GameLauncherModal from "@/gamehub/GameLauncherModal";
+import type { GameWord } from "@/games/PeacockConveyorSorter";
+
+type Mode = "practice" | "assignment";
+
+const PRACTICE_MODE: Mode = "practice";
+
+type Props = {
+  fetchImpl?: typeof fetch;
+};
+
+function getCookie(name: string): string | null {
+  const value = `; ${document.cookie}`;
+  const parts = value.split(`; ${name}=`);
+  if (parts.length === 2) {
+    const segment = parts.pop();
+    if (segment) {
+      return segment.split(";").shift() ?? null;
+    }
+  }
+  return null;
+}
+
+function ReviewSessionInner({ fetchImpl = fetch }: Props) {
+  const fetchFn = fetchImpl;
+  const [queue, setQueue] = useState<ReviewWord[]>([]);
+  const [current, setCurrent] = useState<ReviewWord | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [launcherOpen, setLauncherOpen] = useState(false);
+  const [sessionPoints, setSessionPoints] = useState(0);
+  const [streak, setStreak] = useState(0);
+  const { onQuestionResult } = useEnergyMeter();
+
+  const jsonHeaders = useCallback(() => {
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    const csrftoken = getCookie("csrftoken");
+    if (csrftoken) headers["X-CSRFToken"] = csrftoken;
+    return headers;
+  }, []);
+
+  const loadQueue = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetchFn("/api/srs/queue?limit=30&mode=mix", { credentials: "include" });
+      const data: unknown = await response.json();
+      const items = Array.isArray(data) ? (data as ReviewWord[]) : [];
+      setQueue(items);
+      setCurrent(items[0] ?? null);
+    } catch (err) {
+      console.error("Failed to load SRS queue", err);
+      setError("Unable to load practice queue.");
+      setQueue([]);
+      setCurrent(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [fetchFn]);
+
+  useEffect(() => {
+    loadQueue();
+  }, [loadQueue]);
+
+  useEffect(() => {
+    if (queue.length > 0) {
+      setCurrent(queue[0]);
+    } else {
+      setCurrent(null);
+    }
+  }, [queue]);
+
+  const handleResult = useCallback(
+    async (correct: boolean, extra: CardSubmitExtra = {}) => {
+      if (!current) return;
+
+      const payload = {
+        word_id: current.word_id,
+        activity_type: current.suggested_next_activity,
+        is_correct: correct,
+        ...extra,
+      };
+
+      const remaining = queue.slice(1);
+      setQueue(remaining);
+      setCurrent(remaining[0] ?? null);
+
+      const nextStreakValue = correct ? streak + 1 : 0;
+      setStreak(nextStreakValue);
+      onQuestionResult({ correct, streak: nextStreakValue });
+
+      if (correct) {
+        setSessionPoints(prev => prev + 10);
+      }
+
+      try {
+        await fetchFn("/api/srs/attempt", {
+          method: "POST",
+          headers: jsonHeaders(),
+          credentials: "include",
+          body: JSON.stringify(payload),
+        });
+      } catch (err) {
+        console.error("Failed to submit attempt", err);
+      } finally {
+        if (remaining.length === 0) {
+          await loadQueue();
+        }
+      }
+    },
+    [current, fetchFn, jsonHeaders, loadQueue, onQuestionResult, queue, streak]
+  );
+
+  const card = useMemo(() => {
+    if (!current) return null;
+    const cardProps: CardProps = { word: current, onSubmit: handleResult };
+    switch (current.suggested_next_activity) {
+      case "tapping":
+        return <TappingCard {...cardProps} />;
+      case "mcq":
+        return <MCQCard {...cardProps} />;
+      case "typing":
+        return <TypingCard {...cardProps} />;
+      case "listening":
+        return <ListeningCard {...cardProps} />;
+      default:
+        return <ExposureCard {...cardProps} />;
+    }
+  }, [current, handleResult]);
+
+  const fetchWords = useCallback(
+    async (mode: Mode) => {
+      const response = await fetchFn(`/api/srs/current-words?mode=${mode}`, {
+        credentials: "include",
+      });
+      if (!response.ok) {
+        throw new Error("Failed to load current words");
+      }
+      const data: unknown = await response.json();
+      if (!Array.isArray(data)) {
+        throw new Error("Invalid words payload");
+      }
+      return data as GameWord[];
+    },
+    [fetchFn]
+  );
+
+  const postResult = useCallback(
+    async (body: unknown) => {
+      const response = await fetchFn("/api/srs/game-result", {
+        method: "POST",
+        headers: jsonHeaders(),
+        credentials: "include",
+        body: JSON.stringify(body),
+      });
+      if (!response.ok) {
+        throw new Error("Failed to record game result");
+      }
+    },
+    [fetchFn, jsonHeaders]
+  );
+
+  const awardSession = useCallback(
+    async (body: { pointsDelta: number; streakDelta: number; energyDelta: number; tokensDelta: number }) => {
+      const response = await fetchFn("/api/srs/session-award", {
+        method: "POST",
+        headers: jsonHeaders(),
+        credentials: "include",
+        body: JSON.stringify(body),
+      });
+      if (!response.ok) {
+        throw new Error("Failed to apply session awards");
+      }
+      setSessionPoints(prev => prev + (body.pointsDelta ?? 0));
+      if (body.streakDelta) {
+        setStreak(prev => Math.max(prev + body.streakDelta, 0));
+      }
+    },
+    [fetchFn, jsonHeaders]
+  );
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <div className="flex flex-wrap items-center justify-between gap-4 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+        <div>
+          <h2 className="text-lg font-semibold text-slate-900">Practice Session</h2>
+          <p className="text-sm text-slate-500">Session Points: {sessionPoints}</p>
+          <p className="text-sm text-slate-500">Current Streak: {streak}</p>
+        </div>
+        <EnergyMeter onLaunch={() => setLauncherOpen(true)} />
+      </div>
+
+      {error ? <div className="rounded-lg bg-red-50 p-4 text-sm text-red-600">{error}</div> : null}
+
+      <div className="min-h-[200px] rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+        {loading ? (
+          <div className="text-center text-sm text-slate-500">Loading…</div>
+        ) : card ? (
+          card
+        ) : (
+          <div className="text-center text-sm text-slate-500">All done for now! 🎉</div>
+        )}
+      </div>
+
+      <GameLauncherModal
+        open={launcherOpen}
+        onClose={() => setLauncherOpen(false)}
+        mode={PRACTICE_MODE}
+        fetchWords={fetchWords}
+        postResult={postResult}
+        awardSession={awardSession}
+      />
+    </div>
+  );
+}
+
+export default function ReviewSession(props: Props) {
+  return (
+    <GameHubProvider>
+      <ReviewSessionInner {...props} />
+    </GameHubProvider>
+  );
+}

--- a/srs/frontend/cards/ExposureCard.js
+++ b/srs/frontend/cards/ExposureCard.js
@@ -1,12 +1,18 @@
 import React from 'react';
 
 export default function ExposureCard({ word, onSubmit }) {
-  return React.createElement('div', null, [
-    React.createElement('p', { key: 'prompt' }, word.prompt || ''),
+  return React.createElement(
+    'div',
+    { className: 'flex flex-col items-center gap-4' },
+    React.createElement('p', { className: 'text-xl font-semibold text-slate-800' }, word?.prompt ?? ''),
     React.createElement(
       'button',
-      { key: 'btn', type: 'button', onClick: () => onSubmit(true), className: 'btn btn-primary' },
+      {
+        type: 'button',
+        onClick: () => onSubmit(true),
+        className: 'px-4 py-2 rounded-lg bg-blue-500 text-white shadow hover:bg-blue-600',
+      },
       'Next'
     )
-  ]);
+  );
 }

--- a/srs/frontend/cards/ExposureCard.tsx
+++ b/srs/frontend/cards/ExposureCard.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { CardProps } from "../types";
+
+export default function ExposureCard({ word, onSubmit }: CardProps) {
+  return (
+    <div className="flex flex-col items-center gap-4">
+      <p className="text-xl font-semibold text-slate-800">{word.prompt ?? ""}</p>
+      <button
+        type="button"
+        onClick={() => onSubmit(true)}
+        className="px-4 py-2 rounded-lg bg-blue-500 text-white shadow hover:bg-blue-600"
+      >
+        Next
+      </button>
+    </div>
+  );
+}

--- a/srs/frontend/cards/ListeningCard.js
+++ b/srs/frontend/cards/ListeningCard.js
@@ -1,12 +1,20 @@
 import React from 'react';
 
 export default function ListeningCard({ word, onSubmit }) {
-  return React.createElement('div', null, [
-    word.audio ? React.createElement('audio', { key: 'audio', src: word.audio, controls: true }) : null,
+  const audioSrc = word?.audio ? String(word.audio) : null;
+
+  return React.createElement(
+    'div',
+    { className: 'flex flex-col items-center gap-4' },
+    audioSrc ? React.createElement('audio', { src: audioSrc, controls: true, className: 'w-full' }) : null,
     React.createElement(
       'button',
-      { key: 'btn', type: 'button', onClick: () => onSubmit(true), className: 'btn btn-primary' },
+      {
+        type: 'button',
+        onClick: () => onSubmit(true),
+        className: 'px-4 py-2 rounded-lg bg-indigo-500 text-white shadow hover:bg-indigo-600',
+      },
       'Heard'
     )
-  ]);
+  );
 }

--- a/srs/frontend/cards/ListeningCard.tsx
+++ b/srs/frontend/cards/ListeningCard.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { CardProps } from "../types";
+
+export default function ListeningCard({ word, onSubmit }: CardProps) {
+  const audioSrc = word.audio ? String(word.audio) : null;
+
+  return (
+    <div className="flex flex-col items-center gap-4">
+      {audioSrc ? <audio src={audioSrc} controls className="w-full" /> : null}
+      <button
+        type="button"
+        onClick={() => onSubmit(true)}
+        className="px-4 py-2 rounded-lg bg-indigo-500 text-white shadow hover:bg-indigo-600"
+      >
+        Heard
+      </button>
+    </div>
+  );
+}

--- a/srs/frontend/cards/MCQCard.js
+++ b/srs/frontend/cards/MCQCard.js
@@ -1,21 +1,23 @@
 import React from 'react';
 
 export default function MCQCard({ word, onSubmit }) {
-  const choices = word.choices || [];
+  const choices = Array.isArray(word?.choices) ? word.choices : [];
+
   return React.createElement(
     'div',
-    null,
-    choices.map(choice =>
-      React.createElement(
+    { className: 'grid gap-2' },
+    choices.map(choice => {
+      const label = String(choice);
+      return React.createElement(
         'button',
         {
-          key: choice,
+          key: label,
           type: 'button',
-          onClick: () => onSubmit(choice === word.answer),
-          className: 'btn btn-primary m-1'
+          onClick: () => onSubmit(label === (word?.answer ?? '')),
+          className: 'px-4 py-2 rounded-lg border border-slate-300 hover:bg-slate-100',
         },
-        choice
-      )
-    )
+        label
+      );
+    })
   );
 }

--- a/srs/frontend/cards/MCQCard.tsx
+++ b/srs/frontend/cards/MCQCard.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { CardProps } from "../types";
+
+export default function MCQCard({ word, onSubmit }: CardProps) {
+  const choices = Array.isArray(word.choices) ? word.choices : [];
+
+  return (
+    <div className="grid gap-2">
+      {choices.map(choice => {
+        const label = String(choice);
+        return (
+          <button
+            key={label}
+            type="button"
+            onClick={() => onSubmit(label === (word.answer ?? ""))}
+            className="px-4 py-2 rounded-lg border border-slate-300 hover:bg-slate-100"
+          >
+            {label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/srs/frontend/cards/TappingCard.js
+++ b/srs/frontend/cards/TappingCard.js
@@ -1,12 +1,18 @@
 import React from 'react';
 
 export default function TappingCard({ word, onSubmit }) {
-  return React.createElement('div', null, [
-    React.createElement('p', { key: 'prompt' }, word.prompt || ''),
+  return React.createElement(
+    'div',
+    { className: 'flex flex-col items-center gap-4' },
+    React.createElement('p', { className: 'text-xl font-semibold text-slate-800' }, word?.prompt ?? ''),
     React.createElement(
       'button',
-      { key: 'btn', type: 'button', onClick: () => onSubmit(true), className: 'btn btn-primary' },
+      {
+        type: 'button',
+        onClick: () => onSubmit(true),
+        className: 'px-4 py-2 rounded-lg bg-purple-500 text-white shadow hover:bg-purple-600',
+      },
       'Continue'
     )
-  ]);
+  );
 }

--- a/srs/frontend/cards/TappingCard.tsx
+++ b/srs/frontend/cards/TappingCard.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { CardProps } from "../types";
+
+export default function TappingCard({ word, onSubmit }: CardProps) {
+  return (
+    <div className="flex flex-col items-center gap-4">
+      <p className="text-xl font-semibold text-slate-800">{word.prompt ?? ""}</p>
+      <button
+        type="button"
+        onClick={() => onSubmit(true)}
+        className="px-4 py-2 rounded-lg bg-purple-500 text-white shadow hover:bg-purple-600"
+      >
+        Continue
+      </button>
+    </div>
+  );
+}

--- a/srs/frontend/cards/TypingCard.js
+++ b/srs/frontend/cards/TypingCard.js
@@ -2,24 +2,30 @@ import React, { useState } from 'react';
 
 export default function TypingCard({ word, onSubmit }) {
   const [value, setValue] = useState('');
-  function handleSubmit(e) {
-    e.preventDefault();
-    onSubmit(value.trim().toLowerCase() === (word.answer || '').toLowerCase(), { user_answer: value });
+
+  function handleSubmit(event) {
+    event.preventDefault();
+    const expected = (word?.answer ?? '').toString().trim().toLowerCase();
+    const guess = value.trim().toLowerCase();
+    onSubmit(guess === expected, { user_answer: value });
   }
+
   return React.createElement(
     'form',
-    { onSubmit: handleSubmit },
-    [
-      React.createElement('input', {
-        key: 'input',
-        value,
-        onChange: e => setValue(e.target.value)
-      }),
-      React.createElement(
-        'button',
-        { key: 'btn', type: 'submit', className: 'btn btn-primary' },
-        'Check'
-      )
-    ]
+    { onSubmit: handleSubmit, className: 'flex flex-col items-center gap-3' },
+    React.createElement('input', {
+      value,
+      onChange: event => setValue(event.target.value),
+      className: 'w-full max-w-xs rounded border border-slate-300 px-3 py-2',
+      'aria-label': 'Type your answer',
+    }),
+    React.createElement(
+      'button',
+      {
+        type: 'submit',
+        className: 'px-4 py-2 rounded-lg bg-emerald-500 text-white shadow hover:bg-emerald-600',
+      },
+      'Check'
+    )
   );
 }

--- a/srs/frontend/cards/TypingCard.tsx
+++ b/srs/frontend/cards/TypingCard.tsx
@@ -1,0 +1,27 @@
+import React, { FormEvent, useState } from "react";
+import { CardProps } from "../types";
+
+export default function TypingCard({ word, onSubmit }: CardProps) {
+  const [value, setValue] = useState("");
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const expected = (word.answer ?? "").toString().trim().toLowerCase();
+    const guess = value.trim().toLowerCase();
+    onSubmit(guess === expected, { user_answer: value });
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col items-center gap-3">
+      <input
+        value={value}
+        onChange={event => setValue(event.target.value)}
+        className="w-full max-w-xs rounded border border-slate-300 px-3 py-2"
+        aria-label="Type your answer"
+      />
+      <button type="submit" className="px-4 py-2 rounded-lg bg-emerald-500 text-white shadow hover:bg-emerald-600">
+        Check
+      </button>
+    </form>
+  );
+}

--- a/srs/frontend/types.ts
+++ b/srs/frontend/types.ts
@@ -1,0 +1,16 @@
+export type ReviewWord = {
+  word_id?: number;
+  prompt?: string;
+  answer?: string;
+  choices?: string[];
+  audio?: string;
+  suggested_next_activity?: string;
+  [key: string]: unknown;
+};
+
+export type CardSubmitExtra = Record<string, unknown>;
+
+export type CardProps = {
+  word: ReviewWord;
+  onSubmit: (correct: boolean, extra?: CardSubmitExtra) => void | Promise<void>;
+};

--- a/static/js/gamehub.js
+++ b/static/js/gamehub.js
@@ -1,0 +1,292 @@
+(function (global) {
+  const KEY = "pavonify_gamehub_v1";
+  const MAX_TOKENS = 3;
+  const listeners = new Set();
+  const state = {
+    energy: 0,
+    tokens: 0,
+    maxTokens: MAX_TOKENS,
+  };
+
+  function clampEnergy(value) {
+    if (!Number.isFinite(value)) return 0;
+    return Math.min(100, Math.max(0, Math.round(value)));
+  }
+
+  function clampTokens(value) {
+    if (!Number.isFinite(value)) return 0;
+    return Math.min(state.maxTokens, Math.max(0, Math.round(value)));
+  }
+
+  function loadState() {
+    try {
+      const raw = global.localStorage ? global.localStorage.getItem(KEY) : null;
+      if (!raw) return;
+      const parsed = JSON.parse(raw);
+      if (typeof parsed.energy === "number") {
+        state.energy = clampEnergy(parsed.energy);
+      }
+      if (typeof parsed.tokens === "number") {
+        state.tokens = clampTokens(parsed.tokens);
+      }
+    } catch (error) {
+      console.warn("GameHub: failed to load state", error);
+    }
+  }
+
+  function persistState() {
+    try {
+      if (!global.localStorage) return;
+      global.localStorage.setItem(
+        KEY,
+        JSON.stringify({ energy: state.energy, tokens: state.tokens })
+      );
+    } catch (error) {
+      console.warn("GameHub: failed to persist state", error);
+    }
+  }
+
+  function notify() {
+    const snapshot = getState();
+    listeners.forEach(listener => {
+      try {
+        listener(snapshot);
+      } catch (error) {
+        console.error("GameHub listener error", error);
+      }
+    });
+  }
+
+  function getState() {
+    return {
+      energy: state.energy,
+      tokens: state.tokens,
+      maxTokens: state.maxTokens,
+    };
+  }
+
+  function setEnergy(value) {
+    state.energy = clampEnergy(value);
+    persistState();
+    notify();
+  }
+
+  function resetEnergy() {
+    setEnergy(0);
+  }
+
+  function setTokens(value) {
+    state.tokens = clampTokens(value);
+    persistState();
+    notify();
+  }
+
+  function gainEnergy(base, streak) {
+    const safeBase = Number.isFinite(base) ? Math.max(0, Math.round(base)) : 0;
+    const safeStreak = Number.isFinite(streak) ? streak : 0;
+    const bonus = safeStreak >= 20 ? 2 : safeStreak >= 10 ? 1 : 0;
+    let nextEnergy = state.energy + safeBase + bonus;
+    let nextTokens = state.tokens;
+
+    while (nextEnergy >= 100 && nextTokens < state.maxTokens) {
+      nextEnergy -= 100;
+      nextTokens += 1;
+    }
+
+    if (nextTokens >= state.maxTokens) {
+      nextEnergy = Math.min(nextEnergy, 99);
+    }
+
+    state.energy = clampEnergy(nextEnergy);
+    state.tokens = clampTokens(nextTokens);
+    persistState();
+    notify();
+  }
+
+  function consumeToken() {
+    if (state.tokens <= 0) {
+      return false;
+    }
+    state.tokens = clampTokens(state.tokens - 1);
+    persistState();
+    notify();
+    return true;
+  }
+
+  function restoreToken() {
+    if (state.tokens >= state.maxTokens) {
+      return false;
+    }
+    state.tokens = clampTokens(state.tokens + 1);
+    persistState();
+    notify();
+    return true;
+  }
+
+  function subscribe(listener) {
+    if (typeof listener !== "function") {
+      return function unsubscribe() {};
+    }
+    listeners.add(listener);
+    try {
+      listener(getState());
+    } catch (error) {
+      console.error("GameHub listener error", error);
+    }
+    return function unsubscribe() {
+      listeners.delete(listener);
+    };
+  }
+
+  function ensureEnergyStyles() {
+    if (document.getElementById("gamehub-energy-styles")) {
+      return;
+    }
+    const style = document.createElement("style");
+    style.id = "gamehub-energy-styles";
+    style.textContent = `
+      .gamehub-energy-container {
+        display: inline-flex;
+        align-items: center;
+        gap: 12px;
+      }
+      .gamehub-energy-bar {
+        position: relative;
+        width: 160px;
+        height: 20px;
+        border-radius: 9999px;
+        background: #e0f2fe;
+        overflow: hidden;
+        box-shadow: inset 0 0 0 1px rgba(14, 116, 144, 0.12);
+      }
+      .gamehub-energy-fill {
+        position: absolute;
+        left: 0;
+        top: 0;
+        bottom: 0;
+        width: 0;
+        background: linear-gradient(90deg, #38bdf8 0%, #0ea5e9 100%);
+        transition: width 0.3s ease;
+      }
+      .gamehub-energy-label {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 12px;
+        font-weight: 600;
+        color: #0f172a;
+        text-shadow: 0 1px 2px rgba(255, 255, 255, 0.6);
+        pointer-events: none;
+      }
+      .gamehub-energy-button {
+        border: none;
+        border-radius: 9999px;
+        padding: 6px 14px;
+        font-size: 14px;
+        font-weight: 600;
+        background: #e5e7eb;
+        color: #6b7280;
+        cursor: not-allowed;
+        transition: transform 0.2s ease, background-color 0.2s ease, color 0.2s ease;
+        box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.25);
+      }
+      .gamehub-energy-button.is-active {
+        background: linear-gradient(90deg, #10b981 0%, #059669 100%);
+        color: #ffffff;
+        cursor: pointer;
+        box-shadow: 0 10px 20px rgba(16, 185, 129, 0.25);
+      }
+      .gamehub-energy-button.is-active:hover {
+        transform: scale(1.05);
+      }
+      .gamehub-energy-button:focus {
+        outline: none;
+        box-shadow: 0 0 0 3px rgba(14, 165, 233, 0.35);
+      }
+    `;
+    document.head.appendChild(style);
+  }
+
+  function renderEnergyMeter(container, options = {}) {
+    if (!container) {
+      return function noop() {};
+    }
+    ensureEnergyStyles();
+    container.innerHTML = "";
+
+    const wrapper = document.createElement("div");
+    wrapper.className = "gamehub-energy-container";
+
+    const bar = document.createElement("div");
+    bar.className = "gamehub-energy-bar";
+    const fill = document.createElement("div");
+    fill.className = "gamehub-energy-fill";
+    const label = document.createElement("div");
+    label.className = "gamehub-energy-label";
+    label.textContent = "0% Energy";
+
+    bar.appendChild(fill);
+    bar.appendChild(label);
+
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "gamehub-energy-button";
+    button.textContent = `🎮 x0/${state.maxTokens}`;
+    button.disabled = true;
+
+    wrapper.appendChild(bar);
+    wrapper.appendChild(button);
+    container.appendChild(wrapper);
+
+    const onLaunch = typeof options.onLaunch === "function" ? options.onLaunch : null;
+
+    function update(snapshot) {
+      const pct = clampEnergy(snapshot.energy);
+      fill.style.width = `${pct}%`;
+      label.textContent = `${pct}% Energy`;
+      button.textContent = `🎮 x${snapshot.tokens}/${snapshot.maxTokens}`;
+      button.disabled = snapshot.tokens <= 0;
+      if (snapshot.tokens > 0) {
+        button.classList.add("is-active");
+      } else {
+        button.classList.remove("is-active");
+      }
+    }
+
+    const unsubscribe = subscribe(update);
+
+    function handleClick() {
+      if (button.disabled) {
+        return;
+      }
+      if (onLaunch) {
+        onLaunch();
+      }
+    }
+
+    button.addEventListener("click", handleClick);
+
+    return function destroy() {
+      unsubscribe();
+      button.removeEventListener("click", handleClick);
+      if (container.contains(wrapper)) {
+        container.removeChild(wrapper);
+      }
+    };
+  }
+
+  loadState();
+
+  global.GameHub = {
+    getState,
+    subscribe,
+    gainEnergy,
+    consumeToken,
+    restoreToken,
+    resetEnergy,
+    setEnergy,
+    renderEnergyMeter,
+  };
+})(typeof window !== "undefined" ? window : globalThis);

--- a/static/js/mini_game_launcher.js
+++ b/static/js/mini_game_launcher.js
@@ -1,0 +1,637 @@
+(function (global) {
+  const DEFAULT_TIME_LIMIT = 90000;
+  const OVERLAY_ID = "gamehub-mini-game-overlay";
+  const STYLE_ID = "gamehub-mini-game-styles";
+  let active = null;
+
+  function ensureStyles() {
+    if (document.getElementById(STYLE_ID)) {
+      return;
+    }
+    const style = document.createElement("style");
+    style.id = STYLE_ID;
+    style.textContent = `
+      .gamehub-mini-overlay {
+        position: fixed;
+        inset: 0;
+        background: rgba(15, 23, 42, 0.55);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 24px;
+        z-index: 1050;
+        backdrop-filter: blur(2px);
+      }
+      .gamehub-mini-modal {
+        width: 100%;
+        max-width: 720px;
+        background: #ffffff;
+        border-radius: 24px;
+        box-shadow: 0 24px 48px rgba(15, 23, 42, 0.35);
+        overflow: hidden;
+        display: flex;
+        flex-direction: column;
+        font-family: 'Poppins', sans-serif;
+      }
+      .gamehub-mini-body {
+        padding: 28px;
+        display: flex;
+        flex-direction: column;
+        gap: 20px;
+      }
+      .gamehub-mini-header {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 16px;
+        justify-content: space-between;
+        align-items: center;
+        border: 1px solid rgba(148, 163, 184, 0.3);
+        border-radius: 16px;
+        background: #f8fafc;
+        padding: 16px 20px;
+      }
+      .gamehub-mini-header-block {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        min-width: 120px;
+      }
+      .gamehub-mini-header-label {
+        font-size: 12px;
+        font-weight: 600;
+        text-transform: uppercase;
+        color: #64748b;
+        letter-spacing: 0.05em;
+      }
+      .gamehub-mini-header-value {
+        font-size: 26px;
+        font-weight: 700;
+        color: #0f172a;
+      }
+      .gamehub-mini-header-value.positive {
+        color: #059669;
+      }
+      .gamehub-mini-header-value.negative {
+        color: #dc2626;
+      }
+      .gamehub-mini-word {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        text-align: center;
+      }
+      .gamehub-mini-word-prompt {
+        font-size: 22px;
+        font-weight: 700;
+        color: #0f172a;
+      }
+      .gamehub-mini-word-answer {
+        font-size: 16px;
+        color: #334155;
+      }
+      .gamehub-mini-buttons {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+        justify-content: center;
+      }
+      .gamehub-mini-button {
+        flex: 1 1 160px;
+        border: none;
+        border-radius: 12px;
+        padding: 14px 18px;
+        font-size: 16px;
+        font-weight: 600;
+        cursor: pointer;
+        color: #ffffff;
+        box-shadow: 0 10px 22px rgba(15, 23, 42, 0.15);
+        transition: transform 0.15s ease, box-shadow 0.15s ease;
+      }
+      .gamehub-mini-button.correct {
+        background: linear-gradient(90deg, #22c55e 0%, #16a34a 100%);
+      }
+      .gamehub-mini-button.correct:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 12px 28px rgba(34, 197, 94, 0.25);
+      }
+      .gamehub-mini-button.incorrect {
+        background: linear-gradient(90deg, #f43f5e 0%, #e11d48 100%);
+      }
+      .gamehub-mini-button.incorrect:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 12px 28px rgba(244, 63, 94, 0.25);
+      }
+      .gamehub-mini-finish {
+        align-self: center;
+        padding: 10px 18px;
+        border-radius: 999px;
+        font-size: 14px;
+        font-weight: 600;
+        color: #0f172a;
+        border: 1px solid rgba(148, 163, 184, 0.4);
+        background: #ffffff;
+        cursor: pointer;
+        transition: background 0.15s ease, color 0.15s ease;
+      }
+      .gamehub-mini-finish:hover {
+        background: #0f172a;
+        color: #ffffff;
+      }
+      .gamehub-mini-loading,
+      .gamehub-mini-error,
+      .gamehub-mini-saving {
+        text-align: center;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+      .gamehub-mini-status-title {
+        font-size: 20px;
+        font-weight: 700;
+        color: #0f172a;
+      }
+      .gamehub-mini-status-detail {
+        font-size: 14px;
+        color: #475569;
+      }
+      .gamehub-mini-close {
+        align-self: center;
+        padding: 10px 18px;
+        border-radius: 999px;
+        font-size: 14px;
+        font-weight: 600;
+        border: none;
+        background: #0ea5e9;
+        color: #ffffff;
+        cursor: pointer;
+      }
+      @media (max-width: 600px) {
+        .gamehub-mini-body {
+          padding: 20px;
+        }
+        .gamehub-mini-button {
+          flex: 1 1 100%;
+        }
+      }
+    `;
+    document.head.appendChild(style);
+  }
+
+  function createOverlay() {
+    const existing = document.getElementById(OVERLAY_ID);
+    if (existing && existing.parentNode) {
+      existing.parentNode.removeChild(existing);
+    }
+    const backdrop = document.createElement("div");
+    backdrop.className = "gamehub-mini-overlay";
+    backdrop.id = OVERLAY_ID;
+
+    const modal = document.createElement("div");
+    modal.className = "gamehub-mini-modal";
+
+    const body = document.createElement("div");
+    body.className = "gamehub-mini-body";
+
+    modal.appendChild(body);
+    backdrop.appendChild(modal);
+
+    return { backdrop, modal, body };
+  }
+
+  function computeSummary(entries, startedAt) {
+    const correct = entries.filter(entry => entry.correct).length;
+    const wrong = entries.length - correct;
+    const total = entries.length;
+    const accuracy = total > 0 ? correct / total : 0;
+    const timeMs = Math.max(0, Date.now() - startedAt);
+
+    return {
+      score: correct * 10,
+      accuracy,
+      correct,
+      wrong,
+      wordsSeen: entries.map(entry => entry.word),
+      timeMs,
+    };
+  }
+
+  function setBodyContent(contentElement) {
+    if (!active) return;
+    const { body } = active.overlay;
+    body.innerHTML = "";
+    body.appendChild(contentElement);
+  }
+
+  function showLoading(message) {
+    const container = document.createElement("div");
+    container.className = "gamehub-mini-loading";
+    const title = document.createElement("div");
+    title.className = "gamehub-mini-status-title";
+    title.textContent = message;
+    const detail = document.createElement("div");
+    detail.className = "gamehub-mini-status-detail";
+    detail.textContent = "Fetching your current word set…";
+    container.appendChild(title);
+    container.appendChild(detail);
+    setBodyContent(container);
+  }
+
+  function showSaving(summary) {
+    const container = document.createElement("div");
+    container.className = "gamehub-mini-saving";
+    const title = document.createElement("div");
+    title.className = "gamehub-mini-status-title";
+    title.textContent = "Saving your mini-game results…";
+    const detail = document.createElement("div");
+    detail.className = "gamehub-mini-status-detail";
+    const accuracyPct = Math.round(summary.accuracy * 100);
+    detail.textContent = `Score: ${summary.score} • Accuracy: ${accuracyPct}%`;
+    container.appendChild(title);
+    container.appendChild(detail);
+    setBodyContent(container);
+  }
+
+  function showError(message, { restoreToken } = {}) {
+    if (!active) return;
+    active.state = "error";
+    const container = document.createElement("div");
+    container.className = "gamehub-mini-error";
+    const title = document.createElement("div");
+    title.className = "gamehub-mini-status-title";
+    title.textContent = "Something went wrong";
+    const detail = document.createElement("div");
+    detail.className = "gamehub-mini-status-detail";
+    detail.textContent = message;
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "gamehub-mini-close";
+    button.textContent = "Close";
+    button.addEventListener("click", () => {
+      if (restoreToken && global.GameHub && typeof global.GameHub.restoreToken === "function") {
+        global.GameHub.restoreToken();
+      }
+      closeModal();
+    });
+    container.appendChild(title);
+    container.appendChild(detail);
+    container.appendChild(button);
+    setBodyContent(container);
+  }
+
+  function closeModal() {
+    if (!active) return;
+    if (active.timerId) {
+      global.clearInterval(active.timerId);
+    }
+    if (active.cleanup) {
+      try {
+        active.cleanup();
+      } catch (error) {
+        console.error("MiniGame cleanup error", error);
+      }
+    }
+    const overlay = active.overlay;
+    const options = active.options;
+    if (overlay && overlay.backdrop && overlay.backdrop.parentNode) {
+      overlay.backdrop.parentNode.removeChild(overlay.backdrop);
+    }
+    active = null;
+    if (options && typeof options.onClose === "function") {
+      try {
+        options.onClose();
+      } catch (error) {
+        console.error("MiniGame onClose error", error);
+      }
+    }
+  }
+
+  function markResult(isCorrect) {
+    if (!active || active.state !== "playing") {
+      return;
+    }
+    const words = active.words;
+    if (!Array.isArray(words) || words.length === 0) {
+      finishGame([]);
+      return;
+    }
+    const currentWord = words[active.index] || null;
+    if (!currentWord) {
+      finishGame(active.results);
+      return;
+    }
+    active.results.push({ word: currentWord, correct: !!isCorrect });
+    updateCounts();
+    active.index = (active.index + 1) % words.length;
+    renderCurrentWord();
+
+    if (active.results.length >= words.length) {
+      global.setTimeout(() => finishGame(active.results.slice()), 0);
+    }
+  }
+
+  function computeTimeLeftMs() {
+    if (!active) return 0;
+    const elapsed = Date.now() - active.startedAt;
+    const remaining = Math.max(0, active.timeLimitMs - elapsed);
+    return remaining;
+  }
+
+  function updateTimer() {
+    if (!active || active.state !== "playing") {
+      return;
+    }
+    const remaining = computeTimeLeftMs();
+    if (active.timeEl) {
+      active.timeEl.textContent = `${Math.ceil(remaining / 1000)}s`;
+    }
+    if (remaining <= 0) {
+      finishGame(active.results.slice());
+    }
+  }
+
+  function updateCounts() {
+    if (!active || !Array.isArray(active.results)) {
+      return;
+    }
+    const correct = active.results.filter(entry => entry.correct).length;
+    const wrong = active.results.length - correct;
+    if (active.correctEl) {
+      active.correctEl.textContent = correct;
+    }
+    if (active.wrongEl) {
+      active.wrongEl.textContent = wrong;
+    }
+  }
+
+  function renderCurrentWord() {
+    if (!active) return;
+    const words = active.words || [];
+    const currentWord = words[active.index] || words[0] || null;
+    if (!active.promptEl || !active.answerEl) {
+      return;
+    }
+    if (!currentWord) {
+      active.promptEl.textContent = "No words available.";
+      active.answerEl.textContent = "";
+      active.answerEl.style.display = "none";
+      return;
+    }
+    const prompt = currentWord.prompt || currentWord.question || currentWord.text || "";
+    const answer = currentWord.answer || currentWord.translation || "";
+    active.promptEl.textContent = prompt || "—";
+    if (answer) {
+      active.answerEl.textContent = `Target: ${answer}`;
+      active.answerEl.style.display = "block";
+    } else {
+      active.answerEl.textContent = "";
+      active.answerEl.style.display = "none";
+    }
+  }
+
+  function startGame(words) {
+    if (!active) return;
+    const safeWords = Array.isArray(words) ? words.filter(Boolean) : [];
+    active.words = safeWords;
+    active.results = [];
+    active.index = 0;
+    active.startedAt = Date.now();
+    active.timeLimitMs = Number.isFinite(active.options.timeLimitMs)
+      ? active.options.timeLimitMs
+      : DEFAULT_TIME_LIMIT;
+
+    if (safeWords.length === 0) {
+      showLoading("No words available right now");
+      finishGame([]);
+      return;
+    }
+
+    active.state = "playing";
+
+    const body = active.overlay.body;
+    body.innerHTML = "";
+
+    const header = document.createElement("div");
+    header.className = "gamehub-mini-header";
+
+    const timeBlock = document.createElement("div");
+    timeBlock.className = "gamehub-mini-header-block";
+    const timeLabel = document.createElement("div");
+    timeLabel.className = "gamehub-mini-header-label";
+    timeLabel.textContent = "Time Left";
+    const timeValue = document.createElement("div");
+    timeValue.className = "gamehub-mini-header-value";
+    timeValue.textContent = `${Math.ceil(active.timeLimitMs / 1000)}s`;
+    timeBlock.appendChild(timeLabel);
+    timeBlock.appendChild(timeValue);
+
+    const correctBlock = document.createElement("div");
+    correctBlock.className = "gamehub-mini-header-block";
+    const correctLabel = document.createElement("div");
+    correctLabel.className = "gamehub-mini-header-label";
+    correctLabel.textContent = "Fed";
+    const correctValue = document.createElement("div");
+    correctValue.className = "gamehub-mini-header-value positive";
+    correctValue.textContent = "0";
+    correctBlock.appendChild(correctLabel);
+    correctBlock.appendChild(correctValue);
+
+    const wrongBlock = document.createElement("div");
+    wrongBlock.className = "gamehub-mini-header-block";
+    const wrongLabel = document.createElement("div");
+    wrongLabel.className = "gamehub-mini-header-label";
+    wrongLabel.textContent = "Missed";
+    const wrongValue = document.createElement("div");
+    wrongValue.className = "gamehub-mini-header-value negative";
+    wrongValue.textContent = "0";
+    wrongBlock.appendChild(wrongLabel);
+    wrongBlock.appendChild(wrongValue);
+
+    header.appendChild(timeBlock);
+    header.appendChild(correctBlock);
+    header.appendChild(wrongBlock);
+
+    const wordSection = document.createElement("div");
+    wordSection.className = "gamehub-mini-word";
+    const promptEl = document.createElement("div");
+    promptEl.className = "gamehub-mini-word-prompt";
+    const answerEl = document.createElement("div");
+    answerEl.className = "gamehub-mini-word-answer";
+    wordSection.appendChild(promptEl);
+    wordSection.appendChild(answerEl);
+
+    const buttonsRow = document.createElement("div");
+    buttonsRow.className = "gamehub-mini-buttons";
+    const correctButton = document.createElement("button");
+    correctButton.type = "button";
+    correctButton.className = "gamehub-mini-button correct";
+    correctButton.textContent = "Fed Correctly";
+    const wrongButton = document.createElement("button");
+    wrongButton.type = "button";
+    wrongButton.className = "gamehub-mini-button incorrect";
+    wrongButton.textContent = "Missed";
+    buttonsRow.appendChild(correctButton);
+    buttonsRow.appendChild(wrongButton);
+
+    const finishButton = document.createElement("button");
+    finishButton.type = "button";
+    finishButton.className = "gamehub-mini-finish";
+    finishButton.textContent = "Finish Early";
+
+    body.appendChild(header);
+    body.appendChild(wordSection);
+    body.appendChild(buttonsRow);
+    body.appendChild(finishButton);
+
+    active.timeEl = timeValue;
+    active.correctEl = correctValue;
+    active.wrongEl = wrongValue;
+    active.promptEl = promptEl;
+    active.answerEl = answerEl;
+
+    const handleCorrect = () => markResult(true);
+    const handleWrong = () => markResult(false);
+    const handleFinish = () => finishGame(active.results.slice());
+
+    correctButton.addEventListener("click", handleCorrect);
+    wrongButton.addEventListener("click", handleWrong);
+    finishButton.addEventListener("click", handleFinish);
+
+    active.cleanup = () => {
+      correctButton.removeEventListener("click", handleCorrect);
+      wrongButton.removeEventListener("click", handleWrong);
+      finishButton.removeEventListener("click", handleFinish);
+    };
+
+    renderCurrentWord();
+    updateCounts();
+    updateTimer();
+
+    active.timerId = global.setInterval(updateTimer, 250);
+  }
+
+  function finishGame(forcedEntries) {
+    if (!active) return;
+    if (active.state === "saving") {
+      return;
+    }
+    if (active.timerId) {
+      global.clearInterval(active.timerId);
+      active.timerId = null;
+    }
+    if (active.cleanup) {
+      active.cleanup();
+      active.cleanup = null;
+    }
+
+    const entries = Array.isArray(forcedEntries)
+      ? forcedEntries
+      : active.results || [];
+
+    const startedAt = active.startedAt || Date.now();
+    const summary = computeSummary(entries, startedAt);
+    showSaving(summary);
+    active.state = "saving";
+
+    const payload = {
+      gameKey: "peacock-conveyor",
+      mode: active.options.mode || "practice",
+      ...summary,
+      startedAt,
+      endedAt: Date.now(),
+    };
+
+    Promise.resolve()
+      .then(() => {
+        if (active.options.postResult) {
+          return active.options.postResult(payload);
+        }
+        return null;
+      })
+      .then(() => {
+        const streakDelta = summary.accuracy >= 0.9 && summary.correct >= 15 ? 5 : 0;
+        const award = {
+          pointsDelta: summary.score,
+          streakDelta,
+          energyDelta: 0,
+          tokensDelta: 0,
+        };
+        if (active.options.awardSession) {
+          return Promise.resolve(active.options.awardSession(award, summary)).then(() => award);
+        }
+        return award;
+      })
+      .then(award => {
+        if (active.options.onSessionAward) {
+          try {
+            active.options.onSessionAward(award, summary);
+          } catch (error) {
+            console.error("MiniGame onSessionAward error", error);
+          }
+        }
+        closeModal();
+      })
+      .catch(error => {
+        console.error("MiniGame finalization error", error);
+        showError("We couldn't save your mini-game results. Please try again later.", { restoreToken: false });
+      });
+  }
+
+  function open(options = {}) {
+    if (active) {
+      return;
+    }
+    if (!global.GameHub || typeof global.GameHub.consumeToken !== "function") {
+      console.warn("MiniGameLauncher requires GameHub");
+      return;
+    }
+    if (!global.GameHub.consumeToken()) {
+      return;
+    }
+
+    ensureStyles();
+    const overlay = createOverlay();
+    document.body.appendChild(overlay.backdrop);
+
+    active = {
+      options,
+      overlay,
+      state: "loading",
+      timerId: null,
+      cleanup: null,
+      words: [],
+      results: [],
+      index: 0,
+      startedAt: Date.now(),
+      timeLimitMs: Number.isFinite(options.timeLimitMs) ? options.timeLimitMs : DEFAULT_TIME_LIMIT,
+      timeEl: null,
+      correctEl: null,
+      wrongEl: null,
+      promptEl: null,
+      answerEl: null,
+    };
+
+    showLoading("Loading words…");
+
+    Promise.resolve()
+      .then(() => {
+        if (options.fetchWords) {
+          return options.fetchWords(options.mode || "practice");
+        }
+        return [];
+      })
+      .then(words => {
+        if (!active) {
+          return;
+        }
+        startGame(words);
+      })
+      .catch(error => {
+        console.error("Failed to load mini-game words", error);
+        showError("Unable to load your mini-game. Please close and try again.", { restoreToken: true });
+      });
+  }
+
+  global.MiniGameLauncher = {
+    open,
+  };
+})(typeof window !== "undefined" ? window : globalThis);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "module": "ESNext",
+    "moduleResolution": "NodeNext",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["frontend/src/*"]
+    },
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "frontend/src/**/*",
+    "achievements/frontend/**/*",
+    "srs/frontend/**/*.{ts,tsx}",
+    "types.d.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- add a reusable browser GameHub helper and mini-game launcher overlay scripts that manage energy, tokens, and mini-game sessions with persistence
- embed the energy meter UI and mini-game launcher into the independent practice template, awarding energy on correct answers and calling the new APIs after mini-games
- extend the assignment practice template with the same energy/token experience, updating assignment points and streaks when games conclude

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca90d0df8c8325932f8c1cfd50f0f2