### PR TITLE
Allow up to 300 vocabulary words per list

### DIFF
--- a/learning/forms.py
+++ b/learning/forms.py
@@ -71,13 +71,13 @@ class VocabularyListForm(forms.ModelForm):
         fields = ['name', 'source_language', 'target_language']
 
 class BulkAddWordsForm(forms.Form):
+    MAX_WORDS = 300
+    MAX_LENGTH = 100
+
     words = forms.CharField(
         widget=forms.Textarea,
-        help_text="Add words in the format: word,translation (one pair per line)."
+        help_text=f"Add up to {MAX_WORDS} words in the format: word,translation (one pair per line)."
     )
-
-    MAX_WORDS = 100
-    MAX_LENGTH = 100
 
     def clean_words(self):
         """Validate and normalize bulk word input."""

--- a/learning/templates/learning/add_words_to_list.html
+++ b/learning/templates/learning/add_words_to_list.html
@@ -126,6 +126,11 @@
     background-color: #087bb8;
   }
 
+  .preview-btn[disabled] {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
   /* Back Link */
   .back-link {
     display: inline-block;
@@ -584,8 +589,11 @@
     const modal = document.getElementById('bulk-enrichment-modal');
     const closeButton = document.getElementById('bulk-enrichment-close');
     const rootContainer = document.getElementById('bulk-enrichment-root');
+    const textarea = document.querySelector('textarea[name="words"]');
+    const ENRICHMENT_LIMIT = 100;
+    const ENRICHMENT_DISABLED_TOOLTIP = 'enhancements disabled above 100 words';
 
-    if (!previewButton || !modal || !rootContainer) {
+    if (!previewButton || !modal || !rootContainer || !textarea) {
       return;
     }
 
@@ -643,14 +651,39 @@
       return Array.from(seen.values());
     }
 
-    previewButton.addEventListener('click', function () {
-      const textarea = document.querySelector('textarea[name="words"]');
-      if (!textarea) {
-        return;
+    function setEnhancementAvailability(entriesCount) {
+      const shouldDisable = entriesCount > ENRICHMENT_LIMIT;
+      previewButton.disabled = shouldDisable;
+      if (shouldDisable) {
+        previewButton.setAttribute('title', ENRICHMENT_DISABLED_TOOLTIP);
+        previewButton.setAttribute('aria-disabled', 'true');
+      } else {
+        previewButton.removeAttribute('title');
+        previewButton.removeAttribute('aria-disabled');
       }
-      const entries = parseWords(textarea.value);
+      return shouldDisable;
+    }
+
+    function getCurrentEntries() {
+      return parseWords(textarea.value);
+    }
+
+    function refreshEnhancementButton() {
+      const entries = getCurrentEntries();
+      setEnhancementAvailability(entries.length);
+      return entries;
+    }
+
+    textarea.addEventListener('input', refreshEnhancementButton);
+    refreshEnhancementButton();
+
+    previewButton.addEventListener('click', function () {
+      const entries = refreshEnhancementButton();
       if (entries.length === 0) {
         alert('Please add at least one word before previewing.');
+        return;
+      }
+      if (entries.length > ENRICHMENT_LIMIT) {
         return;
       }
       confirmed = false;


### PR DESCRIPTION
## Summary
- raise the bulk add form limit to allow up to 300 vocabulary entries at once
- update the add words page to disable the enhancements preview button when more than 100 words are entered and show a tooltip explaining why

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68cb6f6149888325ae6e984b304e1b6f