### PR TITLE
Add landing blog link and refresh blog styling

### DIFF
--- a/blog/templates/blog/blog_detail.html
+++ b/blog/templates/blog/blog_detail.html
@@ -4,122 +4,426 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    
-    <title>{{ post.title }} - Pavonify Blog</title>
-    <meta name="description" content="{{ post.content|truncatewords:25 }}">
 
-    <!-- ✅ Import Font Awesome for icons -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    <title>{{ post.title }} - Pavonify Blog</title>
+    <meta name="description" content="{{ post.content|striptags|truncatewords:25 }}">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&family=Fredoka+One&family=Source+Code+Pro:wght@400;500&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SzlrxWUlpfuzQ+pcUCosxcglQRNAq/DZjVsC0lE40xsADsfeQoEypE+enwcOiGjk/bSuGGKHEyjSoQ1zVisanQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
 
     <style>
-    @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Fredoka+One&display=swap');
-    h1 { font-family: 'Fredoka One', cursive; }
-        /* General Styles */
-        body {
-            font-family: 'Poppins', sans-serif;
-            margin: 0;
-            padding: 0;
-            min-height: 100vh;
-            background: #e3f2fd;
-            display: flex;
-            flex-direction: column;
-            align-items: center;
+      :root {
+        --primary: #1A73E8;
+        --accent: #F2A03D;
+        --secondary-accent: #34A853;
+        --background: #F2EFE9;
+        --dark: #0D0D0D;
+        --highlight: #A6173D;
+      }
+
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      body {
+        font-family: 'Poppins', sans-serif;
+        background: var(--background);
+        color: var(--dark);
+        line-height: 1.75;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+      }
+
+      a {
+        color: var(--primary);
+        text-decoration: none;
+        transition: color 0.3s ease, transform 0.3s ease;
+      }
+
+      a:hover,
+      a:focus {
+        color: var(--accent);
+      }
+
+      header {
+        background: linear-gradient(135deg, var(--primary), #2050D0);
+        color: #fff;
+        padding: 80px 20px 60px;
+        position: relative;
+        overflow: hidden;
+      }
+
+      header::after {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: radial-gradient(circle at top left, rgba(255, 255, 255, 0.25), transparent 60%);
+        pointer-events: none;
+      }
+
+      .header-inner {
+        max-width: 900px;
+        margin: 0 auto;
+        position: relative;
+        z-index: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 18px;
+      }
+
+      .breadcrumb {
+        display: inline-flex;
+        align-items: center;
+        gap: 10px;
+        padding: 8px 16px;
+        border-radius: 999px;
+        background: rgba(255, 255, 255, 0.18);
+        color: #fff;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        width: fit-content;
+      }
+
+      .breadcrumb:hover {
+        color: #fff;
+        background: rgba(255, 255, 255, 0.3);
+      }
+
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        background: rgba(255, 255, 255, 0.2);
+        color: #fff;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-weight: 600;
+        font-size: 0.8rem;
+        padding: 8px 18px;
+        border-radius: 999px;
+      }
+
+      header h1 {
+        font-family: 'Fredoka One', cursive;
+        font-size: 3rem;
+        letter-spacing: 1px;
+      }
+
+      .header-meta {
+        display: flex;
+        align-items: center;
+        gap: 18px;
+        flex-wrap: wrap;
+        font-size: 0.95rem;
+        color: rgba(255, 255, 255, 0.9);
+      }
+
+      .header-meta span,
+      .header-meta time {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+      }
+
+      .header-meta i {
+        font-size: 1rem;
+      }
+
+      nav {
+        background: #fff;
+        box-shadow: 0 12px 30px rgba(26, 115, 232, 0.08);
+        padding: 14px 24px;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        gap: 28px;
+        position: sticky;
+        top: 0;
+        z-index: 20;
+      }
+
+      nav a {
+        font-weight: 600;
+        text-transform: uppercase;
+        font-size: 0.9rem;
+        letter-spacing: 0.08em;
+        color: var(--dark);
+        padding-bottom: 6px;
+        border-bottom: 2px solid transparent;
+        transition: color 0.3s ease, border-color 0.3s ease;
+      }
+
+      nav a:hover,
+      nav a:focus-visible {
+        color: var(--accent);
+        border-color: var(--accent);
+        outline: none;
+      }
+
+      nav a.active,
+      nav a[aria-current="page"] {
+        color: var(--primary);
+        border-color: var(--primary);
+      }
+
+      main {
+        flex: 1;
+        width: 100%;
+        max-width: 900px;
+        margin: 0 auto;
+        padding: 50px 20px 80px;
+        display: flex;
+        flex-direction: column;
+        gap: 40px;
+      }
+
+      article {
+        background: #fff;
+        border-radius: 22px;
+        box-shadow: 0 28px 55px rgba(26, 115, 232, 0.1);
+        padding: 48px;
+        display: flex;
+        flex-direction: column;
+        gap: 28px;
+      }
+
+      .article-image {
+        border-radius: 18px;
+        overflow: hidden;
+        box-shadow: 0 20px 40px rgba(15, 23, 42, 0.15);
+      }
+
+      .article-image img {
+        width: 100%;
+        height: auto;
+        display: block;
+      }
+
+      .article-content {
+        font-size: 1.05rem;
+        color: #2f3133;
+        display: flex;
+        flex-direction: column;
+        gap: 1.2em;
+      }
+
+      .article-content p {
+        margin: 0;
+      }
+
+      .article-content h2,
+      .article-content h3,
+      .article-content h4 {
+        font-family: 'Fredoka One', cursive;
+        color: var(--primary);
+        margin: 1.6em 0 0.6em;
+        line-height: 1.3;
+      }
+
+      .article-content ul,
+      .article-content ol {
+        padding-left: 1.5em;
+        display: grid;
+        gap: 0.6em;
+      }
+
+      .article-content a {
+        color: var(--highlight);
+        font-weight: 600;
+        text-decoration: underline;
+        text-decoration-thickness: 2px;
+        text-decoration-color: rgba(166, 23, 61, 0.3);
+      }
+
+      .article-content blockquote {
+        border-left: 4px solid var(--accent);
+        padding: 0.6em 1.4em;
+        background: rgba(242, 160, 61, 0.08);
+        border-radius: 12px;
+        font-style: italic;
+        color: #4a4d50;
+      }
+
+      .article-content code {
+        font-family: 'Source Code Pro', monospace;
+        background: rgba(26, 115, 232, 0.08);
+        padding: 2px 6px;
+        border-radius: 6px;
+        font-size: 0.95em;
+      }
+
+      .article-content pre {
+        background: #0f172a;
+        color: #e2e8f0;
+        padding: 18px;
+        border-radius: 14px;
+        overflow-x: auto;
+        font-size: 0.9rem;
+      }
+
+      .article-content img {
+        max-width: 100%;
+        border-radius: 14px;
+        box-shadow: 0 18px 36px rgba(15, 23, 42, 0.12);
+      }
+
+      .article-actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 16px;
+        justify-content: space-between;
+        align-items: center;
+      }
+
+      .back-link {
+        display: inline-flex;
+        align-items: center;
+        gap: 10px;
+        padding: 10px 20px;
+        border-radius: 999px;
+        border: 2px solid var(--primary);
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+
+      .back-link:hover {
+        color: #fff;
+        background: var(--primary);
+      }
+
+      .cta-button {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 10px;
+        padding: 14px 28px;
+        border-radius: 999px;
+        background: var(--accent);
+        color: #fff;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        box-shadow: 0 18px 30px rgba(242, 160, 61, 0.35);
+      }
+
+      .cta-button:hover {
+        background: var(--highlight);
+        color: #fff;
+      }
+
+      footer {
+        text-align: center;
+        padding: 30px 20px 60px;
+        color: #5f6368;
+        font-size: 0.9rem;
+      }
+
+      footer a {
+        color: var(--primary);
+        font-weight: 600;
+      }
+
+      @media (max-width: 900px) {
+        header h1 {
+          font-size: 2.6rem;
+        }
+      }
+
+      @media (max-width: 768px) {
+        nav {
+          flex-wrap: wrap;
+          gap: 16px;
         }
 
-        /* Blog Header */
-        .blog-header {
-            background-color: #0aa2ef;
-            color: white;
-            text-align: center;
-            padding: 20px;
-            width: 100%;
-            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+        nav a {
+          margin: 4px 0;
         }
 
-        .blog-header h1 {
-            margin: 0;
-            font-size: 28px;
+        main {
+          padding: 40px 16px 60px;
         }
 
-        /* Blog Post Container */
-        .blog-container {
-            width: 90%;
-            max-width: 800px;
-            margin: 20px auto;
-            padding: 20px;
-            background: white;
-            border-radius: 10px;
-            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-            text-align: left;
+        article {
+          padding: 32px;
         }
 
-        .blog-container h1 {
-            margin-top: 0;
-            color: #0aa2ef;
-            font-size: 28px;
+        .article-actions {
+          flex-direction: column;
+          align-items: stretch;
         }
 
-        .blog-container p {
-            font-size: 16px;
-            color: #333;
-            line-height: 1.6;
+        .back-link,
+        .cta-button {
+          justify-content: center;
         }
+      }
 
-        .blog-container .meta {
-            font-size: 14px;
-            color: #555;
-            margin-bottom: 15px;
+      @media (prefers-reduced-motion: reduce) {
+        *,
+        *::before,
+        *::after {
+          animation-duration: 0.01ms !important;
+          animation-iteration-count: 1 !important;
+          transition-duration: 0.01ms !important;
+          scroll-behavior: auto !important;
         }
-
-        /* Featured Image */
-        .blog-image {
-            width: 100%;
-            height: auto;
-            border-radius: 5px;
-            margin: 15px 0;
-            box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
-        }
-
-        /* Return Button */
-        .return-btn {
-            display: inline-block;
-            margin-top: 20px;
-            padding: 10px 15px;
-            background-color: #ff2c61;
-            color: white;
-            border-radius: 5px;
-            text-decoration: none;
-            font-size: 16px;
-            transition: background-color 0.3s ease;
-        }
-
-        .return-btn:hover {
-            background-color: #d4204c;
-        }
+      }
     </style>
 </head>
 <body>
-
-    <!-- Blog Header -->
-    <div class="blog-header">
-        <h1>📝 Pavonify Blog</h1>
-    </div>
-
-    <!-- Blog Post Content -->
-    <div class="blog-container">
+    <header>
+      <div class="header-inner">
+        <a class="breadcrumb" href="{% url 'blog_list' %}"><i class="fas fa-arrow-left" aria-hidden="true"></i> All articles</a>
+        <span class="badge"><i class="fas fa-star" aria-hidden="true"></i> Pavonify Blog</span>
         <h1>{{ post.title }}</h1>
-        <p class="meta">By {{ post.author }} | {{ post.created_at|date:"F j, Y" }}</p>
+        <div class="header-meta">
+          <span><i class="fas fa-user" aria-hidden="true"></i> {{ post.author }}</span>
+          <time datetime="{{ post.created_at|date:'c' }}"><i class="fas fa-calendar-alt" aria-hidden="true"></i> {{ post.created_at|date:"F j, Y" }}</time>
+          <span><i class="fas fa-pen" aria-hidden="true"></i> Updated {{ post.updated_at|date:"F j, Y" }}</span>
+        </div>
+      </div>
+    </header>
 
+    <nav>
+      <a href="{% url 'landing_page' %}#features">Features</a>
+      <a href="{% url 'landing_page' %}#comparison">Comparison</a>
+      <a href="{% url 'landing_page' %}#roadmap">Roadmap</a>
+      <a href="{% url 'blog_list' %}" class="active" aria-current="page">Blog</a>
+      <a href="mailto:contact@pavonify.com">Contact</a>
+    </nav>
+
+    <main>
+      <article>
         {% if post.featured_image %}
-            <img src="{{ post.featured_image.url }}" alt="{{ post.title }}" class="blog-image">
+        <figure class="article-image">
+          <img src="{{ post.featured_image.url }}" alt="{{ post.title }}">
+        </figure>
         {% endif %}
 
-        <p>{{ post.content|linebreaks|safe }}</p>
-    </div>
+        <div class="article-content">
+          {{ post.content|linebreaks|safe }}
+        </div>
+      </article>
 
-    <!-- Return to Blog Button -->
-    <a href="{% url 'blog_list' %}" class="return-btn"><i class="fas fa-arrow-left"></i> Return to Blog</a>
+      <div class="article-actions">
+        <a class="back-link" href="{% url 'blog_list' %}"><i class="fas fa-arrow-left" aria-hidden="true"></i> Back to all posts</a>
+        <a class="cta-button" href="{% url 'register_teacher' %}">
+          Try Pavonify for free <i class="fas fa-arrow-right" aria-hidden="true"></i>
+        </a>
+      </div>
+    </main>
 
-{% include 'messages.html' %}
+    <footer>
+      <p>&copy; {% now "Y" %} Pavonify. Ready when you are to energise language learning.</p>
+    </footer>
+
+    {% include 'messages.html' %}
 </body>
 </html>

--- a/blog/templates/blog/blog_list.html
+++ b/blog/templates/blog/blog_list.html
@@ -4,128 +4,499 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    
+
     <title>Pavonify Blog</title>
-    <meta name="description" content="Read the latest updates, teaching tips, and insights from Pavonify.">
-    
-    <!-- ✅ Import Font Awesome for icons -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
-    
+    <meta name="description" content="Read the latest product updates, teaching tips, and insights from the Pavonify team.">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&family=Fredoka+One&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SzlrxWUlpfuzQ+pcUCosxcglQRNAq/DZjVsC0lE40xsADsfeQoEypE+enwcOiGjk/bSuGGKHEyjSoQ1zVisanQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+
     <style>
-    @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Fredoka+One&display=swap');
-    h1 { font-family: 'Fredoka One', cursive; }
-        /* General Styles */
-        body {
-            font-family: 'Poppins', sans-serif;
-            margin: 0;
-            padding: 0;
-            min-height: 100vh;
-            background: #e3f2fd;
-            display: flex;
-            flex-direction: column;
-            align-items: center;
+      :root {
+        --primary: #1A73E8;
+        --accent: #F2A03D;
+        --secondary-accent: #34A853;
+        --background: #F2EFE9;
+        --dark: #0D0D0D;
+        --highlight: #A6173D;
+      }
+
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      body {
+        font-family: 'Poppins', sans-serif;
+        background: var(--background);
+        color: var(--dark);
+        line-height: 1.7;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+      }
+
+      a {
+        color: var(--primary);
+        text-decoration: none;
+        transition: color 0.3s ease, transform 0.3s ease;
+      }
+
+      a:hover,
+      a:focus {
+        color: var(--accent);
+      }
+
+      header {
+        background: linear-gradient(135deg, var(--primary), #2050D0);
+        color: #fff;
+        text-align: center;
+        padding: 70px 20px 60px;
+        position: relative;
+        overflow: hidden;
+      }
+
+      header::after {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: radial-gradient(circle at top left, rgba(255, 255, 255, 0.22), transparent 55%);
+        opacity: 0.9;
+        pointer-events: none;
+      }
+
+      .header-inner {
+        max-width: 960px;
+        margin: 0 auto;
+        position: relative;
+        z-index: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+        align-items: center;
+      }
+
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        background: rgba(255, 255, 255, 0.2);
+        color: #fff;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-weight: 600;
+        font-size: 0.8rem;
+        padding: 8px 18px;
+        border-radius: 999px;
+      }
+
+      header h1 {
+        font-family: 'Fredoka One', cursive;
+        font-size: 3.1rem;
+        letter-spacing: 1px;
+      }
+
+      header p {
+        max-width: 720px;
+        font-size: 1.1rem;
+        color: rgba(255, 255, 255, 0.92);
+      }
+
+      nav {
+        background: #fff;
+        box-shadow: 0 12px 30px rgba(26, 115, 232, 0.08);
+        padding: 14px 24px;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        gap: 28px;
+        position: sticky;
+        top: 0;
+        z-index: 20;
+      }
+
+      nav a {
+        font-weight: 600;
+        text-transform: uppercase;
+        font-size: 0.9rem;
+        letter-spacing: 0.08em;
+        color: var(--dark);
+        padding-bottom: 6px;
+        border-bottom: 2px solid transparent;
+        transition: color 0.3s ease, border-color 0.3s ease;
+      }
+
+      nav a:hover,
+      nav a:focus-visible {
+        color: var(--accent);
+        border-color: var(--accent);
+        outline: none;
+      }
+
+      nav a.active,
+      nav a[aria-current="page"] {
+        color: var(--primary);
+        border-color: var(--primary);
+      }
+
+      .sr-only {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
+      }
+
+      main {
+        flex: 1;
+        width: 100%;
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: 50px 20px 80px;
+        display: flex;
+        flex-direction: column;
+        gap: 50px;
+      }
+
+      .post-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        gap: 30px;
+      }
+
+      .post-card {
+        background: #fff;
+        border-radius: 18px;
+        box-shadow: 0 25px 45px rgba(26, 115, 232, 0.1);
+        padding: 28px;
+        display: flex;
+        flex-direction: column;
+        gap: 18px;
+        transition: transform 0.35s ease, box-shadow 0.35s ease;
+      }
+
+      .post-card:hover {
+        transform: translateY(-8px);
+        box-shadow: 0 32px 60px rgba(26, 115, 232, 0.14);
+      }
+
+      .post-thumb {
+        width: 100%;
+        border-radius: 14px;
+        overflow: hidden;
+        box-shadow: 0 18px 36px rgba(15, 23, 42, 0.12);
+      }
+
+      .post-thumb img {
+        width: 100%;
+        height: auto;
+        display: block;
+      }
+
+      .post-card h2 {
+        margin: 0;
+        font-family: 'Fredoka One', cursive;
+        font-size: 1.9rem;
+        color: var(--primary);
+      }
+
+      .post-card h2 a {
+        color: inherit;
+      }
+
+      .post-card h2 a:hover {
+        color: var(--accent);
+      }
+
+      .post-meta {
+        display: flex;
+        align-items: center;
+        gap: 18px;
+        flex-wrap: wrap;
+        font-size: 0.9rem;
+        color: #5f6368;
+      }
+
+      .meta-item {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+      }
+
+      .meta-item i {
+        color: var(--primary);
+        font-size: 0.95rem;
+      }
+
+      .excerpt {
+        font-size: 1rem;
+        color: #3c4043;
+        margin: 0;
+      }
+
+      .read-more {
+        align-self: flex-start;
+        display: inline-flex;
+        align-items: center;
+        gap: 10px;
+        background: var(--primary);
+        color: #fff;
+        padding: 10px 22px;
+        border-radius: 999px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        box-shadow: 0 12px 24px rgba(26, 115, 232, 0.25);
+      }
+
+      .read-more i {
+        transition: transform 0.3s ease;
+      }
+
+      .read-more:hover {
+        background: var(--accent);
+        color: #fff;
+        box-shadow: 0 16px 30px rgba(242, 160, 61, 0.35);
+      }
+
+      .read-more:hover i {
+        transform: translateX(4px);
+      }
+
+      .empty-state {
+        background: #fff;
+        border-radius: 20px;
+        box-shadow: 0 30px 60px rgba(26, 115, 232, 0.12);
+        padding: 60px 30px;
+        text-align: center;
+        margin: 0 auto;
+        max-width: 720px;
+      }
+
+      .empty-state h2 {
+        font-family: 'Fredoka One', cursive;
+        font-size: 2rem;
+        color: var(--primary);
+        margin-bottom: 16px;
+      }
+
+      .empty-state p {
+        color: #3c4043;
+        margin-bottom: 22px;
+      }
+
+      .empty-state .empty-action {
+        display: inline-flex;
+        align-items: center;
+        gap: 10px;
+        padding: 12px 24px;
+        background: var(--accent);
+        color: #fff;
+        border-radius: 999px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        box-shadow: 0 14px 28px rgba(242, 160, 61, 0.32);
+      }
+
+      .empty-state .empty-action:hover {
+        background: var(--highlight);
+      }
+
+      .cta-banner {
+        background: linear-gradient(135deg, var(--primary), #2B50C7);
+        border-radius: 20px;
+        padding: 50px 30px;
+        text-align: center;
+        color: #fff;
+        box-shadow: 0 35px 60px rgba(26, 115, 232, 0.18);
+        position: relative;
+        overflow: hidden;
+      }
+
+      .cta-banner::after {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: radial-gradient(circle at top right, rgba(255, 255, 255, 0.25), transparent 55%);
+        pointer-events: none;
+      }
+
+      .cta-content {
+        position: relative;
+        z-index: 1;
+        max-width: 720px;
+        margin: 0 auto;
+        display: flex;
+        flex-direction: column;
+        gap: 14px;
+      }
+
+      .cta-banner h2 {
+        font-family: 'Fredoka One', cursive;
+        font-size: 2.2rem;
+      }
+
+      .cta-banner p {
+        margin: 0 auto 1.5rem;
+        color: rgba(255, 255, 255, 0.92);
+      }
+
+      .cta-button {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 10px;
+        padding: 14px 28px;
+        border-radius: 999px;
+        background: #fff;
+        color: var(--primary);
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        box-shadow: 0 18px 30px rgba(15, 23, 42, 0.18);
+      }
+
+      .cta-button:hover {
+        color: var(--highlight);
+        transform: translateY(-2px);
+      }
+
+      .cta-button i {
+        color: var(--accent);
+      }
+
+      footer {
+        text-align: center;
+        padding: 30px 20px 60px;
+        color: #5f6368;
+        font-size: 0.9rem;
+      }
+
+      footer a {
+        color: var(--primary);
+        font-weight: 600;
+      }
+
+      @media (max-width: 900px) {
+        header h1 {
+          font-size: 2.6rem;
+        }
+      }
+
+      @media (max-width: 768px) {
+        nav {
+          flex-wrap: wrap;
+          gap: 16px;
         }
 
-        /* Header */
-        .blog-header {
-            background-color: #0aa2ef;
-            color: white;
-            text-align: center;
-            padding: 20px;
-            width: 100%;
-            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+        nav a {
+          margin: 4px 0;
         }
 
-        .blog-header h1 {
-            margin: 0;
-            font-size: 28px;
+        main {
+          padding: 40px 16px 60px;
         }
 
-        /* Blog Container */
-        .blog-container {
-            width: 90%;
-            max-width: 800px;
-            margin: 20px auto;
-            padding: 20px;
-            background: white;
-            border-radius: 10px;
-            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-            text-align: center;
+        .post-card {
+          padding: 24px;
         }
 
-        .blog-post {
-            margin-bottom: 20px;
-            padding: 20px;
-            border-bottom: 1px solid #ddd;
-            text-align: left;
+        .cta-banner {
+          padding: 40px 20px;
         }
+      }
 
-        .blog-post:last-child {
-            border-bottom: none;
+      @media (prefers-reduced-motion: reduce) {
+        *,
+        *::before,
+        *::after {
+          animation-duration: 0.01ms !important;
+          animation-iteration-count: 1 !important;
+          transition-duration: 0.01ms !important;
+          scroll-behavior: auto !important;
         }
-
-        .blog-post h2 {
-            margin: 0;
-            color: #0aa2ef;
-        }
-
-        .blog-post a {
-            text-decoration: none;
-            color: #0aa2ef;
-            transition: color 0.3s ease-in-out;
-        }
-
-        .blog-post a:hover {
-            color: #086baf;
-        }
-
-        .blog-post p {
-            font-size: 16px;
-            color: #333;
-        }
-
-        /* Back to Homepage Button */
-        .back-btn {
-            display: inline-block;
-            margin-top: 20px;
-            padding: 10px 15px;
-            background-color: #ff2c61;
-            color: white;
-            border-radius: 5px;
-            text-decoration: none;
-            font-size: 16px;
-            transition: background-color 0.3s ease;
-        }
-
-        .back-btn:hover {
-            background-color: #d4204c;
-        }
+      }
     </style>
 </head>
 <body>
+    <header>
+      <div class="header-inner">
+        <span class="badge"><i class="fas fa-star" aria-hidden="true"></i> Pavonify Insights</span>
+        <h1>Pavonify Blog</h1>
+        <p>Dive into classroom stories, product updates, and language teaching inspiration from the Pavonify team.</p>
+      </div>
+    </header>
 
-    <!-- Blog Header -->
-    <div class="blog-header">
-        <h1>📝 Pavonify Blog</h1>
-    </div>
+    <nav>
+      <a href="{% url 'landing_page' %}#features">Features</a>
+      <a href="{% url 'landing_page' %}#comparison">Comparison</a>
+      <a href="{% url 'landing_page' %}#roadmap">Roadmap</a>
+      <a href="{% url 'blog_list' %}" class="active" aria-current="page">Blog</a>
+      <a href="mailto:contact@pavonify.com">Contact</a>
+    </nav>
 
-    <!-- Blog Content -->
-    <div class="blog-container">
+    <main>
+      {% if posts %}
+      <section class="post-grid" aria-label="Latest Pavonify blog posts">
         {% for post in posts %}
-        <div class="blog-post">
-            <h2><a href="{% url 'blog_detail' post.slug %}">{{ post.title }}</a></h2>
-            <p>By {{ post.author }} | {{ post.created_at|date:"F j, Y" }}</p>
-            <p>{{ post.content|truncatewords:30|safe }}</p>
-        </div>
-        {% empty %}
-        <p>No blog posts yet. Check back soon!</p>
+        <article class="post-card">
+          {% if post.featured_image %}
+          <figure class="post-thumb">
+            <img src="{{ post.featured_image.url }}" alt="{{ post.title }}">
+          </figure>
+          {% endif %}
+          <h2><a href="{% url 'blog_detail' post.slug %}">{{ post.title }}</a></h2>
+          <div class="post-meta">
+            <span class="meta-item">
+              <i class="fas fa-user" aria-hidden="true"></i>
+              <span class="sr-only">Author:</span>{{ post.author }}
+            </span>
+            <span class="meta-item">
+              <i class="fas fa-calendar-alt" aria-hidden="true"></i>
+              <span class="sr-only">Published:</span>
+              <time datetime="{{ post.created_at|date:'c' }}">{{ post.created_at|date:"F j, Y" }}</time>
+            </span>
+          </div>
+          <p class="excerpt">{{ post.content|striptags|truncatewords:40 }}</p>
+          <a class="read-more" href="{% url 'blog_detail' post.slug %}">
+            Read Article <i class="fas fa-arrow-right" aria-hidden="true"></i>
+          </a>
+        </article>
         {% endfor %}
-    </div>
+      </section>
+      {% else %}
+      <section class="empty-state" aria-live="polite">
+        <h2>We're writing our first stories</h2>
+        <p>Check back soon for product announcements, teacher tips, and ideas to energise your language classroom.</p>
+        <a class="empty-action" href="{% url 'landing_page' %}#roadmap">
+          Explore our roadmap <i class="fas fa-compass" aria-hidden="true"></i>
+        </a>
+      </section>
+      {% endif %}
 
-    <!-- Back to Homepage Button -->
-<a href="https://www.pavonify.com" class="back-btn"><i class="fas fa-home"></i> Back to Homepage</a>
+      <section class="cta-banner">
+        <div class="cta-content">
+          <h2>Bring Pavonify into your classroom</h2>
+          <p>Join thousands of teachers using AI-powered tools to accelerate language learning. Start for free and upgrade when you’re ready.</p>
+          <a class="cta-button" href="{% url 'register_teacher' %}">
+            Start your free teacher account <i class="fas fa-arrow-right" aria-hidden="true"></i>
+          </a>
+        </div>
+      </section>
+    </main>
 
+    <footer>
+      <p>&copy; {% now "Y" %} Pavonify. Empowering language classrooms with creativity and AI.</p>
+    </footer>
 
-{% include 'messages.html' %}
+    {% include 'messages.html' %}
 </body>
 </html>

--- a/learning/templates/learning/landing_page.html
+++ b/learning/templates/learning/landing_page.html
@@ -520,6 +520,7 @@
     <a href="#features">Features</a>
     <a href="#comparison">Comparison</a>
     <a href="#roadmap">Roadmap</a>
+    <a href="{% url 'blog_list' %}">Blog</a>
     <a href="mailto:contact@pavonify.com">Contact</a>
   </nav>
 


### PR DESCRIPTION
## Summary
- add a dedicated Blog navigation link to the public landing page so the content is discoverable
- restyle the blog list view to align with the current Pavonify branding, typography, and CTA patterns
- refresh the blog detail view with the same theme, enriched metadata, and improved article presentation

## Testing
- python manage.py test blog

------
https://chatgpt.com/codex/tasks/task_e_68cb81261f308325abe1fbd5da898c1a