### PR TITLE
Render blog post HTML content

### DIFF
--- a/blog/templates/blog/blog_detail.html
+++ b/blog/templates/blog/blog_detail.html
@@ -408,7 +408,7 @@
         {% endif %}
 
         <div class="article-content">
-          {{ post.content|linebreaks|safe }}
+          {{ post.content|safe }}
         </div>
       </article>
 


### PR DESCRIPTION
## Summary
- render stored blog post HTML without escaping by removing the `linebreaks` filter from the detail template

## Testing
- python manage.py test blog

------
https://chatgpt.com/codex/tasks/task_e_68cb845748dc8325ab610d1605f0ea51