### PR TITLE
Stabilize assignment analytics modal interactions

### DIFF
--- a/learning/templates/learning/assignment_analytics.html
+++ b/learning/templates/learning/assignment_analytics.html
@@ -188,14 +188,21 @@
       background: rgba(0, 0, 0, 0.45);
       z-index: 1200;
       backdrop-filter: blur(2px);
+      padding: 24px 16px;
+      overflow-y: auto;
+      align-items: flex-start;
+      justify-content: center;
     }
     .modal-dialog {
+      width: 100%;
       max-width: 720px;
-      margin: 10vh auto;
       background: #fff;
       padding: 20px;
       border-radius: 16px;
       box-shadow: 0 16px 40px rgba(0,0,0,0.18);
+      position: relative;
+      max-height: 80vh;
+      overflow: auto;
     }
     .feedback-cards {
       display: grid;
@@ -390,13 +397,13 @@
     </div>
 
     <!-- Minimal modal for clipboard -->
-    <div id="gen-modal">
-      <div class="modal-dialog">
+    <div id="gen-modal" aria-hidden="true">
+      <div class="modal-dialog" role="dialog" aria-modal="true" tabindex="-1" aria-labelledby="gen-title">
         <h3 id="gen-title">Generated Activity</h3>
         <textarea id="gen-clipboard" rows="12"></textarea>
         <div style="display:flex; gap:8px; justify-content:flex-end; margin-top:8px;">
-          <button id="copy-btn">Copy to Clipboard</button>
-          <button id="close-btn">Close</button>
+          <button id="copy-btn" type="button">Copy to Clipboard</button>
+          <button id="close-btn" type="button">Close</button>
         </div>
       </div>
     </div>
@@ -666,18 +673,105 @@
         });
       }
 
+      const modalOverlay = document.getElementById('gen-modal');
+      const modalDialog = modalOverlay ? modalOverlay.querySelector('.modal-dialog') : null;
+      const modalTitle = document.getElementById('gen-title');
+      const modalTextarea = document.getElementById('gen-clipboard');
+      const closeButton = document.getElementById('close-btn');
+      const copyButton = document.getElementById('copy-btn');
+      const pageBody = document.body;
+      let previousBodyOverflow = pageBody ? pageBody.style.overflow : '';
+      let lastTriggerButton = null;
+      let pointerDownInsideDialog = false;
+      let copyResetTimer = null;
+
+      function getEventPoint(event) {
+        if (!event) {
+          return null;
+        }
+        if (typeof event.clientX === 'number' && typeof event.clientY === 'number') {
+          return { x: event.clientX, y: event.clientY };
+        }
+        if (event.touches && event.touches[0]) {
+          const touch = event.touches[0];
+          return { x: touch.clientX, y: touch.clientY };
+        }
+        if (event.changedTouches && event.changedTouches[0]) {
+          const touch = event.changedTouches[0];
+          return { x: touch.clientX, y: touch.clientY };
+        }
+        return null;
+      }
+
+      function isPointInsideDialog(event) {
+        if (!modalDialog) {
+          return false;
+        }
+        const point = getEventPoint(event);
+        if (!point) {
+          return false;
+        }
+        const rect = modalDialog.getBoundingClientRect();
+        return (
+          point.x >= rect.left &&
+          point.x <= rect.right &&
+          point.y >= rect.top &&
+          point.y <= rect.bottom
+        );
+      }
+
       function openModal(title, text) {
-        document.getElementById('gen-title').textContent = title;
-        document.getElementById('gen-clipboard').value = text;
-        document.getElementById('gen-modal').style.display = 'block';
+        if (modalTitle) {
+          modalTitle.textContent = title;
+        }
+        if (modalTextarea) {
+          modalTextarea.value = text;
+          modalTextarea.scrollTop = 0;
+        }
+        if (modalOverlay) {
+          modalOverlay.style.display = 'flex';
+          modalOverlay.setAttribute('aria-hidden', 'false');
+          modalOverlay.scrollTop = 0;
+        }
+        if (pageBody) {
+          previousBodyOverflow = pageBody.style.overflow;
+          pageBody.style.overflow = 'hidden';
+        }
+        if (modalDialog) {
+          try {
+            modalDialog.focus({ preventScroll: true });
+          } catch (err) {
+            modalDialog.focus();
+          }
+        }
       }
 
       function closeModal() {
-        document.getElementById('gen-modal').style.display = 'none';
+        if (modalOverlay) {
+          modalOverlay.style.display = 'none';
+          modalOverlay.setAttribute('aria-hidden', 'true');
+        }
+        if (pageBody) {
+          pageBody.style.overflow = previousBodyOverflow || '';
+        }
+        if (lastTriggerButton) {
+          lastTriggerButton.focus();
+          lastTriggerButton = null;
+        }
+        pointerDownInsideDialog = false;
+        if (copyResetTimer) {
+          window.clearTimeout(copyResetTimer);
+          copyResetTimer = null;
+        }
+        if (copyButton) {
+          copyButton.disabled = false;
+          copyButton.textContent = 'Copy to Clipboard';
+        }
       }
 
       document.querySelectorAll('.btn-gen').forEach((btn) => {
         btn.addEventListener('click', async () => {
+          lastTriggerButton = btn;
           const type = btn.getAttribute('data-type');
           try {
             const response = await postJSON("{% url 'api_generate_activity' %}", {
@@ -691,23 +785,81 @@
         });
       });
 
-      document.getElementById('close-btn').addEventListener('click', closeModal);
-      document.getElementById('gen-modal').addEventListener('click', (event) => {
-        if (event.target === event.currentTarget) {
-          closeModal();
-        }
-      });
+      if (closeButton) {
+        closeButton.addEventListener('click', closeModal);
+      }
 
-      document.getElementById('copy-btn').addEventListener('click', async () => {
-        const textarea = document.getElementById('gen-clipboard');
-        textarea.select();
-        textarea.setSelectionRange(0, textarea.value.length);
-        try {
-          await navigator.clipboard.writeText(textarea.value);
-        } catch (err) {
-          document.execCommand('copy');
+      if (modalOverlay) {
+        const markPointerOrigin = (event) => {
+          pointerDownInsideDialog = isPointInsideDialog(event);
+          if (pointerDownInsideDialog) {
+            event.stopPropagation();
+          }
+        };
+
+        const handleBackdropActivation = (event) => {
+          const pointerUpInsideDialog = isPointInsideDialog(event);
+          if (!pointerDownInsideDialog && !pointerUpInsideDialog) {
+            closeModal();
+          }
+          pointerDownInsideDialog = false;
+        };
+
+        ['pointerdown', 'mousedown', 'touchstart'].forEach((eventName) => {
+          modalOverlay.addEventListener(eventName, markPointerOrigin, true);
+        });
+
+        ['pointerup', 'mouseup', 'touchend', 'click'].forEach((eventName) => {
+          modalOverlay.addEventListener(eventName, handleBackdropActivation);
+        });
+
+        modalOverlay.addEventListener('keydown', (event) => {
+          if (event.key === 'Escape') {
+            closeModal();
+          }
+        });
+      }
+
+      if (modalDialog) {
+        ['click', 'pointerdown', 'pointerup', 'mousedown', 'mouseup', 'touchstart', 'touchend'].forEach((evtName) => {
+          modalDialog.addEventListener(evtName, (event) => {
+            event.stopPropagation();
+          });
+        });
+      }
+
+      function announceCopySuccess() {
+        if (!copyButton) {
+          return;
         }
-      });
+        if (copyResetTimer) {
+          window.clearTimeout(copyResetTimer);
+        }
+        copyButton.disabled = true;
+        copyButton.textContent = 'Copied!';
+        copyResetTimer = window.setTimeout(() => {
+          copyButton.disabled = false;
+          copyButton.textContent = 'Copy to Clipboard';
+          copyResetTimer = null;
+        }, 1600);
+      }
+
+      if (copyButton && modalTextarea) {
+        copyButton.addEventListener('click', async (event) => {
+          event.stopPropagation();
+          modalTextarea.select();
+          modalTextarea.setSelectionRange(0, modalTextarea.value.length);
+          try {
+            await navigator.clipboard.writeText(modalTextarea.value);
+            announceCopySuccess();
+          } catch (err) {
+            const legacyCopied = document.execCommand('copy');
+            if (legacyCopied !== false) {
+              announceCopySuccess();
+            }
+          }
+        });
+      }
     })();
   </script>
 {% include 'messages.html' %}


### PR DESCRIPTION
## Summary
- keep the assignment analytics quick activity modal open while dragging scrollbars or pressing buttons by tracking pointer origin and only closing for true backdrop clicks
- add clipboard feedback handling so the copy button temporarily shows a Copied! state and resets cleanly when the modal closes
- mark the modal action buttons as type="button" to avoid unintended form submission behavior

## Testing
- not run (front-end change only)


------
https://chatgpt.com/codex/tasks/task_e_68cb9b0e73a88325b0fc33c757fd0819