### PR TITLE
Refine analytics feedback UI and add XLSX export

### DIFF
--- a/lang_platform/urls.py
+++ b/lang_platform/urls.py
@@ -22,6 +22,7 @@ from django_countries.fields import CountryField
 from django.contrib import admin
 from django.urls import path
 from learning import views  # Import views from the learning app
+from learning import views_api
 from learning.views import flashcard_mode, delete_reading_lab_text
 from django.contrib.auth.decorators import login_required
 from learning.views import update_assignment_points, log_assignment_attempt, refresh_leaderboard, delete_teacher_account, class_leaderboard, buy_pavicoins, pavicoins_success, teacher_upgrade, create_checkout_session, worksheet_lab_view, custom_404_view, teacher_account_settings, grammar_lab, delete_ladder
@@ -123,6 +124,17 @@ urlpatterns = [
     path('api/achievements/', include('achievements.urls')),
     path("api/vocab/enrichment/preview", EnrichmentPreviewAPI.as_view(), name="vocab-enrichment-preview"),
     path("api/vocab/enrichment/confirm", EnrichmentConfirmAPI.as_view(), name="vocab-enrichment-confirm"),
+    path("api/analytics/<int:assignment_id>/word-stats/", views_api.api_word_stats, name="api_word_stats"),
+    path("api/analytics/<int:assignment_id>/mode-breakdown/", views_api.api_mode_breakdown, name="api_mode_breakdown"),
+    path("api/analytics/<int:assignment_id>/student-mastery/", views_api.api_student_mastery, name="api_student_mastery"),
+    path("api/analytics/<int:assignment_id>/heatmap/", views_api.api_heatmap, name="api_heatmap"),
+    path("api/analytics/<int:assignment_id>/overview/", views_api.api_overview, name="api_overview"),
+    path(
+        "api/analytics/<int:assignment_id>/export/progress/",
+        views_api.api_export_progress,
+        name="api_export_progress",
+    ),
+    path("api/generate-activity/", views_api.api_generate_activity, name="api_generate_activity"),
 
 
 ]

--- a/learning/analytics.py
+++ b/learning/analytics.py
@@ -1,0 +1,394 @@
+from collections import defaultdict
+import math
+import random
+import statistics
+
+from django.db.models import Case, Count, F, Q, Sum, When
+from django.db.models.functions import Coalesce
+
+from .models import (
+    Assignment,
+    AssignmentAttempt,
+    AssignmentProgress,
+    VocabularyWord,
+)
+
+
+# ---------- Core Aggregations ----------
+
+def _student_accuracy_map(assignment_id):
+    """Return mapping of student_id -> overall accuracy for the assignment."""
+    student_stats = (
+        AssignmentAttempt.objects
+        .filter(assignment_id=assignment_id)
+        .values("student_id")
+        .annotate(
+            total_attempts=Count("id"),
+            total_correct=Coalesce(Sum(Case(When(is_correct=True, then=1), default=0)), 0),
+        )
+    )
+    scores = {}
+    for row in student_stats:
+        attempts = row["total_attempts"] or 0
+        correct = row["total_correct"] or 0
+        scores[row["student_id"]] = (correct / attempts) if attempts else 0.0
+    return scores
+
+
+def _point_biserial_for_words(assignment_id, student_scores):
+    """Compute point-biserial discrimination per word based on student scores."""
+    # Prepare accumulator for each word keyed by vocabulary_word_id
+    per_word = defaultdict(lambda: {
+        "correct_score_sum": 0.0,
+        "correct_count": 0,
+        "incorrect_score_sum": 0.0,
+        "incorrect_count": 0,
+    })
+
+    # Aggregate attempts per student per word to determine success grouping
+    per_word_student = (
+        AssignmentAttempt.objects
+        .filter(assignment_id=assignment_id)
+        .values("vocabulary_word_id", "student_id")
+        .annotate(
+            attempts=Count("id"),
+            correct=Coalesce(Sum(Case(When(is_correct=True, then=1), default=0)), 0),
+        )
+    )
+
+    for row in per_word_student:
+        student_id = row["student_id"]
+        word_id = row["vocabulary_word_id"]
+        attempts = row["attempts"] or 0
+        correct = row["correct"] or 0
+        if attempts == 0:
+            continue
+        score = student_scores.get(student_id, 0.0)
+        accuracy = correct / attempts
+        bucket = per_word[word_id]
+        if accuracy >= 0.5:
+            bucket["correct_score_sum"] += score
+            bucket["correct_count"] += 1
+        else:
+            bucket["incorrect_score_sum"] += score
+            bucket["incorrect_count"] += 1
+
+    score_values = list(student_scores.values())
+    if len(score_values) > 1:
+        sd_total = statistics.pstdev(score_values)
+    else:
+        sd_total = 0.0
+
+    results = {}
+    for word_id, bucket in per_word.items():
+        correct_count = bucket["correct_count"]
+        incorrect_count = bucket["incorrect_count"]
+        total_students = correct_count + incorrect_count
+        if not total_students or sd_total == 0:
+            results[word_id] = 0.0
+            continue
+        p = correct_count / total_students
+        q = 1 - p
+        if p == 0 or q == 0:
+            results[word_id] = 0.0
+            continue
+        mean_correct = bucket["correct_score_sum"] / correct_count if correct_count else 0.0
+        mean_incorrect = bucket["incorrect_score_sum"] / incorrect_count if incorrect_count else 0.0
+        discrimination = ((mean_correct - mean_incorrect) / sd_total) * math.sqrt(p * q)
+        results[word_id] = float(discrimination)
+    return results
+
+
+def word_stats(assignment_id):
+    """
+    Returns list of dicts:
+    [{
+      'vocabulary_word': <id>,
+      'word': 'Bibliothek',
+      'attempts': 12,
+      'correct': 7,
+      'students_total': 9,
+      'students_struggling': 5,
+      'facility': 0.58,
+      'difficulty': 0.42,
+      'discrimination': 0.19
+    }, ...] (sorted hardest first)
+    """
+    qs = (
+        AssignmentAttempt.objects
+        .filter(assignment_id=assignment_id)
+        .values("vocabulary_word", "vocabulary_word__word")
+        .annotate(
+            attempts=Count("id"),
+            correct=Coalesce(Sum(Case(When(is_correct=True, then=1), default=0)), 0),
+            students_total=Count("student", distinct=True),
+            students_struggling=Count("student", filter=Q(is_correct=False), distinct=True),
+        )
+        .annotate(
+            facility=(F("correct") * 1.0) / F("attempts"),
+            difficulty=1.0 - (F("correct") * 1.0) / F("attempts"),
+        )
+        .order_by("-difficulty", "-attempts")
+    )
+
+    student_scores = _student_accuracy_map(assignment_id)
+    discrimination_map = _point_biserial_for_words(assignment_id, student_scores)
+
+    results = []
+    for row in qs:
+        word_id = row["vocabulary_word"]
+        results.append({
+            "vocabulary_word": word_id,
+            "word": row["vocabulary_word__word"],
+            "attempts": row["attempts"],
+            "correct": row["correct"],
+            "students_total": row["students_total"],
+            "students_struggling": row["students_struggling"],
+            "facility": float(row["facility"]),
+            "difficulty": float(row["difficulty"]),
+            "discrimination": float(discrimination_map.get(word_id, 0.0)),
+        })
+    return results
+
+
+def mode_breakdown(assignment_id):
+    """
+    Returns list of dicts per mode:
+    [{'mode':'flashcards','attempts':20,'correct':13,'facility':0.65}, ...]
+    """
+    qs = (
+        AssignmentAttempt.objects
+        .filter(assignment_id=assignment_id)
+        .values("mode")
+        .annotate(
+            attempts=Count("id"),
+            correct=Coalesce(Sum(Case(When(is_correct=True, then=1), default=0)), 0),
+        )
+        .annotate(
+            facility=(F("correct") * 1.0) / F("attempts")
+        )
+        .order_by("mode")
+    )
+    return [
+        {
+            "mode": row["mode"],
+            "attempts": row["attempts"],
+            "correct": row["correct"],
+            "facility": float(row["facility"]),
+        }
+        for row in qs
+    ]
+
+
+def student_mastery(assignment_id):
+    """
+    Returns per student lists of 'words_aced' and 'needs_practice'.
+    Aced: >=3 attempts and >=80% correct
+    Needs practice: >=2 attempts and <=50% correct
+    """
+    base = (
+        AssignmentAttempt.objects
+        .filter(assignment_id=assignment_id)
+        .values("student_id", "student__first_name", "student__last_name", "vocabulary_word__word")
+        .annotate(
+            attempts=Count("id"),
+            correct=Coalesce(Sum(Case(When(is_correct=True, then=1), default=0)), 0),
+        )
+    )
+
+    by_student = {}
+    for row in base:
+        sid = row["student_id"]
+        name = f"{row['student__first_name']} {row['student__last_name']}".strip()
+        student_bucket = by_student.setdefault(sid, {
+            "student_id": sid,
+            "name": name,
+            "words_aced": [],
+            "needs_practice": [],
+        })
+        attempts = row["attempts"] or 0
+        acc = (row["correct"] * 1.0) / attempts if attempts else 0.0
+        word = row["vocabulary_word__word"]
+        if attempts >= 3 and acc >= 0.8:
+            student_bucket["words_aced"].append(word)
+        if attempts >= 2 and acc <= 0.5:
+            student_bucket["needs_practice"].append(word)
+
+    return list(by_student.values())
+
+
+def heatmap_data(assignment_id):
+    """
+    Returns JSON-serialisable mapping for heatmap grid.
+    {
+        'students': {sid: 'Name', ...},
+        'words': {wid: 'word', ...},
+        'cells': [
+            {'student': sid, 'word': wid, 'attempts': 3, 'correct': 1, 'accuracy': 0.33},
+            ...
+        ]
+    }
+    """
+    grid = (
+        AssignmentAttempt.objects
+        .filter(assignment_id=assignment_id)
+        .values(
+            "student_id",
+            "student__first_name",
+            "student__last_name",
+            "vocabulary_word_id",
+            "vocabulary_word__word",
+        )
+        .annotate(
+            attempts=Count("id"),
+            correct=Coalesce(Sum(Case(When(is_correct=True, then=1), default=0)), 0),
+        )
+    )
+
+    students, words, cells = {}, {}, []
+    for row in grid:
+        sid = str(row["student_id"])
+        wid = str(row["vocabulary_word_id"])
+        attempts = row["attempts"] or 0
+        correct = row["correct"] or 0
+        students[sid] = f"{row['student__first_name']} {row['student__last_name']}".strip()
+        words[wid] = row["vocabulary_word__word"]
+        accuracy = (correct * 1.0) / attempts if attempts else 0.0
+        cells.append({
+            "student": sid,
+            "word": wid,
+            "attempts": attempts,
+            "correct": correct,
+            "accuracy": round(accuracy, 2),
+        })
+    return {"students": students, "words": words, "cells": cells}
+
+
+def assignment_overview(assignment_id):
+    """
+    Returns list of dicts: username, points_earned, completed, time_spent
+    """
+    qs = (
+        AssignmentProgress.objects
+        .filter(assignment_id=assignment_id)
+        .select_related("student")
+        .values("student__username", "points_earned", "completed", "time_spent")
+        .order_by("-points_earned")
+    )
+    output = []
+    for row in qs:
+        output.append({
+            "username": row["student__username"],
+            "points_earned": row["points_earned"],
+            "completed": row["completed"],
+            "time_spent": str(row["time_spent"]) if row["time_spent"] is not None else "0:00:00",
+        })
+    return output
+
+
+# ---------- Activity Generators (no schema changes) ----------
+
+def _get_vocab_dict(assignment_id):
+    assignment = Assignment.objects.select_related("vocab_list").get(id=assignment_id)
+    vocab = VocabularyWord.objects.filter(list=assignment.vocab_list).values("word", "translation")
+    return assignment, {entry["word"]: entry["translation"] for entry in vocab}
+
+
+def build_do_now(assignment_id, hard_limit=6):
+    stats = word_stats(assignment_id)
+    hardest = [row["word"] for row in stats[:hard_limit]]
+    assignment, vocab_dict = _get_vocab_dict(assignment_id)
+    pool = list(vocab_dict.keys())
+
+    questions = []
+    for word in hardest:
+        distractors_pool = [candidate for candidate in pool if candidate != word]
+        if distractors_pool:
+            distractors = random.sample(distractors_pool, k=min(3, len(distractors_pool)))
+        else:
+            distractors = []
+        options = [word] + distractors
+        random.shuffle(options)
+        questions.append({
+            "stem": f"Choose the correct {assignment.vocab_list.source_language} word for: “{vocab_dict.get(word, word)}”.",
+            "options": options,
+            "answer": word,
+        })
+    return {"title": "Do-Now: Tricky Words (3–5 mins)", "questions": questions}
+
+
+def build_exit_tickets(assignment_id):
+    mastery = student_mastery(assignment_id)
+    tickets = []
+    for entry in mastery:
+        weak = entry["needs_practice"][:2]
+        confident = entry["words_aced"][:1]
+        items = []
+        if weak:
+            items.append({"type": "short", "prompt": f"Translate and type: {weak[0]}."})
+        if len(weak) > 1:
+            items.append({"type": "short", "prompt": f"Translate and type: {weak[1]}."})
+        if confident:
+            items.append({"type": "confidence", "prompt": f"Quick win: use “{confident[0]}” in a short sentence."})
+        if not items:
+            items.append({"type": "short", "prompt": "Write any 2 words you learned and translate them."})
+        tickets.append({"student": entry["name"], "items": items})
+    return {"title": "Exit Tickets (Personalised)", "tickets": tickets}
+
+
+def pick_hinge_question(assignment_id):
+    stats = word_stats(assignment_id)
+    if not stats:
+        return {"title": "Hinge Question", "question": "No data yet."}
+    top = max(stats, key=lambda row: (row["difficulty"], row["attempts"]))
+    return {
+        "title": "Hinge Question",
+        "question": f"Everyone: type the translation for “{top['word']}”.",
+        "note": f"Chosen due to high difficulty ({round(top['difficulty'] * 100)}%) with {top['attempts']} attempts.",
+    }
+
+
+def build_sentence_builders(assignment_id, per_word=4, total_words=8):
+    stats = word_stats(assignment_id)
+    words = [row["word"] for row in stats[:total_words]] if stats else []
+    frames = [
+        "Write a sentence using “{w}” in the past tense.",
+        "Write a question using “{w}”.",
+        "Use “{w}” with an adjective.",
+        "Connect “{w}” with because/aber/et/pero.",
+    ]
+    prompts = []
+    for word in words:
+        for frame in frames[:per_word]:
+            prompts.append({"prompt": frame.format(w=word)})
+    return {"title": "Sentence Builders", "prompts": prompts}
+
+
+def build_game_seed(assignment_id, limit=10):
+    stats = word_stats(assignment_id)
+    words = [row["word"] for row in stats[:limit]]
+    return {
+        "title": "Mini-Game Seed",
+        "game": "conveyor_sorter",
+        "words": words,
+    }
+
+
+def as_plaintext(payload):
+    lines = [payload.get("title", "Activity"), ""]
+    if "questions" in payload:
+        for index, question in enumerate(payload["questions"], 1):
+            lines.append(f"{index}) {question['stem']}")
+            for opt_idx, option in enumerate(question.get("options", []), 1):
+                lines.append(f"   {opt_idx}. {option}")
+    if "prompts" in payload:
+        for index, prompt in enumerate(payload["prompts"], 1):
+            lines.append(f"{index}) {prompt['prompt']}")
+    if "tickets" in payload:
+        for ticket in payload["tickets"]:
+            lines.append(f"- {ticket['student']}")
+            for item in ticket["items"]:
+                lines.append(f"   • {item['prompt']}")
+    if "question" in payload:
+        lines.append(payload["question"])
+    return "\n".join(lines)

--- a/learning/templates/learning/assignment_analytics.html
+++ b/learning/templates/learning/assignment_analytics.html
@@ -95,17 +95,282 @@
       width: 0%;
       transition: width 0.3s;
     }
-    /* Word Clouds */
-    .word-cloud {
-      border: 1px solid #ddd;
-      padding: 10px;
-      min-height: 100px;
-      margin-bottom: 20px;
+    .btn-gen {
+      background: #005f73;
+      color: #fff;
+      border: none;
+      padding: 12px 16px;
+      border-radius: 10px;
+      cursor: pointer;
+      font-weight: 600;
+      min-height: 44px;
+      min-width: 140px;
+      transition: background 0.3s;
     }
-    .word-cloud span {
-      margin: 5px;
-      display: inline-block;
-      transition: transform 0.3s;
+    .btn-gen:hover,
+    .btn-gen:focus {
+      background: #0a9396;
+      outline: none;
+    }
+    .btn-download {
+      background: #fff;
+      border: 2px solid var(--primary);
+      color: var(--primary);
+      padding: 10px 16px;
+      border-radius: 10px;
+      font-weight: 600;
+      cursor: pointer;
+      min-height: 44px;
+      transition: all 0.3s ease;
+      text-decoration: none;
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+    }
+    .btn-download:hover,
+    .btn-download:focus {
+      background: var(--primary);
+      color: #fff;
+    }
+    #teach-now-bar {
+      position: sticky;
+      top: 72px;
+      z-index: 400;
+      background: #fff;
+      padding: 8px 12px;
+      border: 1px solid #eee;
+      border-radius: 10px;
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      margin-bottom: 16px;
+      box-shadow: 0 8px 20px rgba(0,0,0,0.06);
+    }
+    .teach-now-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      justify-content: flex-start;
+    }
+    #gen-clipboard {
+      width: 100%;
+      border-radius: 10px;
+      border: 1px solid #ccc;
+      padding: 10px;
+      font-family: 'Poppins', sans-serif;
+      height: 50vh;
+      resize: vertical;
+    }
+    #copy-btn,
+    #close-btn {
+      border: none;
+      border-radius: 8px;
+      padding: 10px 16px;
+      cursor: pointer;
+      font-weight: 600;
+    }
+    #copy-btn {
+      background: #005f73;
+      color: #fff;
+    }
+    #close-btn {
+      background: #666;
+      color: #fff;
+    }
+    #copy-btn:hover,
+    #close-btn:hover {
+      opacity: 0.9;
+    }
+    #gen-modal {
+      display: none;
+      position: fixed;
+      inset: 0;
+      background: rgba(0, 0, 0, 0.45);
+      z-index: 1200;
+      backdrop-filter: blur(2px);
+    }
+    #gen-modal * {
+      pointer-events: auto;
+    }
+    .modal-dialog {
+      position: relative;
+      max-width: 720px;
+      max-height: 80vh;
+      margin: 10vh auto;
+      background: #fff;
+      padding: 20px;
+      border-radius: 16px;
+      box-shadow: 0 16px 40px rgba(0,0,0,0.18);
+      overflow: auto;
+      pointer-events: auto;
+    }
+    .feedback-cards {
+      display: grid;
+      gap: 16px;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      margin-bottom: 24px;
+      text-align: left;
+    }
+    .feedback-card {
+      background: #f5f9ff;
+      border: 1px solid rgba(26, 115, 232, 0.15);
+      border-radius: 14px;
+      padding: 18px;
+      position: relative;
+      overflow: hidden;
+    }
+    .feedback-card::after {
+      content: "";
+      position: absolute;
+      top: -40px;
+      right: -40px;
+      width: 120px;
+      height: 120px;
+      background: rgba(26, 115, 232, 0.08);
+      border-radius: 50%;
+    }
+    .feedback-card h4 {
+      font-size: 0.9rem;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      color: var(--dark);
+      margin-bottom: 8px;
+    }
+    .feedback-card .metric {
+      font-size: 2.4rem;
+      font-weight: 700;
+      color: var(--primary);
+      margin-bottom: 4px;
+    }
+    .feedback-card p {
+      margin: 0;
+      font-size: 0.85rem;
+      color: #4a4a4a;
+    }
+    .feedback-grid {
+      display: grid;
+      gap: 20px;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      margin-bottom: 24px;
+      text-align: left;
+    }
+    .feedback-panel {
+      background: #fff;
+      border-radius: 14px;
+      padding: 18px;
+      border: 1px solid #eee;
+      box-shadow: 0 12px 24px rgba(13, 13, 13, 0.04);
+    }
+    .feedback-panel.full-width {
+      grid-column: 1 / -1;
+    }
+    .feedback-panel h3 {
+      margin-bottom: 12px;
+      font-size: 1.2rem;
+      color: var(--primary);
+    }
+    .priority-list {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+    .priority-item-title {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      font-weight: 600;
+    }
+    .progress-track {
+      width: 100%;
+      height: 10px;
+      background: #f0f4ff;
+      border-radius: 999px;
+      overflow: hidden;
+      margin-top: 6px;
+    }
+    .progress-fill {
+      height: 100%;
+      background: linear-gradient(90deg, #f97316, #dc2626);
+    }
+    .focus-students {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+    .focus-students li {
+      background: #f9fafb;
+      border-radius: 10px;
+      padding: 10px 12px;
+      border: 1px solid rgba(26, 115, 232, 0.08);
+    }
+    .focus-students .student-name {
+      font-weight: 600;
+      margin-bottom: 4px;
+    }
+    .focus-students .student-meta {
+      font-size: 0.85rem;
+      color: #555;
+    }
+    .focus-students .student-needs {
+      font-size: 0.85rem;
+      margin-top: 4px;
+    }
+    .chip-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+    .chip {
+      background: rgba(52, 168, 83, 0.12);
+      color: #166534;
+      border-radius: 999px;
+      padding: 6px 12px;
+      font-weight: 600;
+      font-size: 0.9rem;
+    }
+    .chip-muted {
+      background: #f3f4f6;
+      color: #6b7280;
+      border-radius: 999px;
+      padding: 6px 12px;
+      font-size: 0.9rem;
+    }
+    .mini-table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+    .mini-table th,
+    .mini-table td {
+      border: 1px solid #e5e7eb;
+      padding: 8px;
+      text-align: left;
+      font-size: 0.95rem;
+    }
+    .mini-table th {
+      background: rgba(26, 115, 232, 0.1);
+      color: #1a237e;
+    }
+    @media (max-width: 640px) {
+      #teach-now-bar {
+        flex-direction: column;
+        align-items: stretch;
+      }
+      .teach-now-actions {
+        width: 100%;
+        justify-content: center;
+      }
+      .btn-download {
+        width: 100%;
+        justify-content: center;
+      }
     }
   </style>
 </head>
@@ -114,10 +379,37 @@
   <div class="top-nav">
     <a href="{% url 'teacher_dashboard' %}?pane=classes">&larr; Back to Dashboard</a>
   </div>
-  
+
   <div class="container">
     <h1>Assignment Analytics: {{ assignment.name }}</h1>
-    
+
+    <!-- Sticky action bar -->
+    <div id="teach-now-bar">
+      <div class="teach-now-actions">
+        <button class="btn-gen" data-type="do_now">Re-teach Do-Now</button>
+        <button class="btn-gen" data-type="exit_tickets">Exit Tickets</button>
+        <button class="btn-gen" data-type="hinge">Live Hinge</button>
+        <button class="btn-gen" data-type="sentences">Sentence Builders</button>
+        <button class="btn-gen" data-type="game_seed">Mini-game</button>
+      </div>
+      <a class="btn-download" href="{% url 'api_export_progress' assignment.id %}">
+        <i class="fas fa-file-arrow-down" aria-hidden="true"></i>
+        <span>Download Progress (.xlsx)</span>
+      </a>
+    </div>
+
+    <!-- Minimal modal for clipboard -->
+    <div id="gen-modal">
+      <div class="modal-dialog">
+        <h3 id="gen-title">Generated Activity</h3>
+        <textarea id="gen-clipboard" rows="12"></textarea>
+        <div style="display:flex; gap:8px; justify-content:flex-end; margin-top:8px;">
+          <button id="copy-btn">Copy to Clipboard</button>
+          <button id="close-btn">Close</button>
+        </div>
+      </div>
+    </div>
+
     <!-- Tab Navigation -->
     <div class="tabs">
       <div class="tab active" data-tab="overview">Overview</div>
@@ -227,35 +519,119 @@
     <!-- Feedback Tab -->
     <div class="tab-content" id="feedback">
       <h2>Feedback</h2>
-      <div>
-        <h3>Word Cloud (Easy)</h3>
-        <div class="word-cloud" id="word-cloud-easy">
-          {% for word in word_cloud_easy %}
-            <span style="font-size: 16px;">{{ word }}</span>
-          {% endfor %}
+      <div class="feedback-cards">
+        <div class="feedback-card">
+          <h4>Class accuracy</h4>
+          <div class="metric">{{ class_accuracy|floatformat:1 }}%</div>
+          <p>{{ total_attempts }} attempts logged across {{ student_summary|length }} students.</p>
+        </div>
+        <div class="feedback-card">
+          <h4>Completed</h4>
+          <div class="metric">{{ students_completed }}</div>
+          <p>students finished the assignment.</p>
+        </div>
+        <div class="feedback-card">
+          <h4>Reteach candidates</h4>
+          <div class="metric">{{ struggling_word_count }}</div>
+          <p>words below 50% accuracy.</p>
+        </div>
+        <div class="feedback-card">
+          <h4>Action tips</h4>
+          <p style="font-size: 0.95rem; margin-top: 24px;">Use the quick-action bar to launch activities targeted at these needs.</p>
         </div>
       </div>
-      <div>
-        <h3>Word Cloud (Difficult)</h3>
-        <div class="word-cloud" id="word-cloud-difficult">
-          {% for word in top_difficult_words %}
-            <span data-difficulty="{{ word.students_difficulty }}">{{ word.word }}</span>
-          {% endfor %}
+
+      <div class="feedback-grid">
+        <div class="feedback-panel">
+          <h3>Priority words to re-teach</h3>
+          <p style="margin-top:-4px; font-size:0.9rem; color:#555;">High-difficulty words ranked by incorrect attempts.</p>
+          <ul class="priority-list">
+            {% for word in top_difficult_words|slice:":5" %}
+              <li>
+                <div class="priority-item-title">
+                  <span>{{ word.word }}</span>
+                  <span>{{ word.difficulty_percentage|floatformat:0 }}% incorrect</span>
+                </div>
+                <div class="progress-track" role="presentation">
+                  <div class="progress-fill" style="width: {{ word.difficulty_percentage|floatformat:0 }}%;"></div>
+                </div>
+                <div class="student-meta" style="font-size:0.8rem; color:#666; margin-top:4px;">
+                  {{ word.students_difficulty }} student{{ word.students_difficulty|pluralize }} struggled • {{ word.total_attempts }} attempts
+                </div>
+              </li>
+            {% empty %}
+              <li>No word difficulty data yet.</li>
+            {% endfor %}
+          </ul>
         </div>
-      </div>
-      <div>
-        <h3>Top 10 Difficult Words</h3>
-        <ol>
-          {% for word in top_difficult_words %}
-            <li>{{ word.word }} - {{ word.students_difficulty }} students</li>
-          {% empty %}
-            <li>No data available.</li>
-          {% endfor %}
-        </ol>
+
+        <div class="feedback-panel">
+          <h3>Students to check in</h3>
+          <p style="margin-top:-4px; font-size:0.9rem; color:#555;">Lowest accuracy learners with at least three attempts.</p>
+          <ul class="focus-students">
+            {% for student in focus_students %}
+              <li>
+                <div class="student-name">{{ student.name }}</div>
+                <div class="student-meta">{{ student.accuracy|floatformat:0 }}% accuracy across {{ student.attempts }} attempts</div>
+                {% if student.needs %}
+                  <div class="student-needs"><strong>Focus words:</strong> {{ student.needs|join:', ' }}</div>
+                {% endif %}
+              </li>
+            {% empty %}
+              <li class="chip-muted">Everyone is on track! 🎉</li>
+            {% endfor %}
+          </ul>
+        </div>
+
+        <div class="feedback-panel">
+          <h3>Confidence boosters</h3>
+          <p style="margin-top:-4px; font-size:0.9rem; color:#555;">Celebrate the vocabulary the class now owns.</p>
+          <div class="chip-row">
+            {% if quick_win_words %}
+              {% for word in quick_win_words %}
+                <span class="chip">{{ word.word }} · {{ word.facility_percentage|floatformat:0 }}%</span>
+              {% endfor %}
+            {% elif celebration_words %}
+              {% for word in celebration_words %}
+                <span class="chip">{{ word }}</span>
+              {% endfor %}
+            {% else %}
+              <span class="chip-muted">No mastery highlights yet.</span>
+            {% endif %}
+          </div>
+        </div>
+
+        <div class="feedback-panel full-width">
+          <h3>Top 10 difficult words</h3>
+          <table class="mini-table">
+            <thead>
+              <tr>
+                <th>Word</th>
+                <th>Incorrect attempts</th>
+                <th>Students affected</th>
+                <th>Difficulty</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for word in top_difficult_words %}
+                <tr>
+                  <td>{{ word.word }}</td>
+                  <td>{{ word.wrong_attempts }}</td>
+                  <td>{{ word.students_difficulty }}</td>
+                  <td>{{ word.difficulty_percentage|floatformat:0 }}%</td>
+                </tr>
+              {% empty %}
+                <tr>
+                  <td colspan="4">No data available.</td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
       </div>
     </div>
   </div>
-  
+
   <script>
     // Tab switching logic.
     const tabs = document.querySelectorAll(".tab");
@@ -268,45 +644,90 @@
         document.getElementById(tab.getAttribute("data-tab")).classList.add("active");
       });
     });
-    
-    // Enhance Word Cloud for Difficult Words:
-    // Use the "data-difficulty" attribute to set a dynamic font size.
-    function enhanceDifficultWordCloud() {
-      const cloud = document.getElementById("word-cloud-difficult");
-      const spans = cloud.querySelectorAll("span");
-      spans.forEach(span => {
-        const difficulty = parseInt(span.getAttribute("data-difficulty")) || 0;
-        // Compute a font size: base 16px plus 2px per student (adjust scaling as needed)
-        const fontSize = 16 + (difficulty * 2);
-        span.style.fontSize = fontSize + "px";
-        // Random color from a preset list
-        const colors = ["#e74c3c", "#3498db", "#2ecc71", "#f1c40f", "#9b59b6"];
-        const randomColor = colors[Math.floor(Math.random() * colors.length)];
-        span.style.color = randomColor;
-        // Random rotation between -15 and 15 degrees.
-        const rotation = Math.floor(Math.random() * 31) - 15;
-        span.style.display = "inline-block";
-        span.style.transform = "rotate(" + rotation + "deg)";
+  </script>
+  <script>
+    (function(){
+      const assignmentId = "{{ assignment.id|escapejs }}";
+
+      function getCookie(name) {
+        const value = `; ${document.cookie}`;
+        const parts = value.split(`; ${name}=`);
+        if (parts.length === 2) return parts.pop().split(';').shift();
+        return null;
+      }
+
+      const modal = document.getElementById('gen-modal');
+      const modalDialog = modal.querySelector('.modal-dialog');
+
+      function postJSON(url, data) {
+        const csrfToken = getCookie('csrftoken');
+        return fetch(url, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Requested-With': 'XMLHttpRequest',
+            'X-CSRFToken': csrfToken || '',
+          },
+          body: JSON.stringify(data),
+          credentials: 'include',
+        }).then(response => {
+          if (!response.ok) {
+            throw new Error('Network response was not ok');
+          }
+          return response.json();
+        });
+      }
+
+      function openModal(title, text) {
+        document.getElementById('gen-title').textContent = title;
+        const textarea = document.getElementById('gen-clipboard');
+        textarea.value = text || '';
+        modal.style.display = 'block';
+        textarea.focus();
+      }
+
+      function closeModal() {
+        modal.style.display = 'none';
+      }
+
+      document.querySelectorAll('.btn-gen').forEach((btn) => {
+        btn.addEventListener('click', async () => {
+          const type = btn.getAttribute('data-type');
+          try {
+            const response = await postJSON("{% url 'api_generate_activity' %}", {
+              assignment_id: assignmentId,
+              activity_type: type,
+            });
+            openModal(response.activity.title || 'Generated', response.clipboard || '');
+          } catch (error) {
+            openModal('Error', 'Could not generate activity.');
+          }
+        });
       });
-    }
-    
-    // Enhance the easy word cloud with random colors and rotations (but constant size)
-    function enhanceEasyWordCloud() {
-      const cloud = document.getElementById("word-cloud-easy");
-      const spans = cloud.querySelectorAll("span");
-      spans.forEach(span => {
-        span.style.fontSize = "16px";
-        const colors = ["#3498db", "#2ecc71", "#f1c40f", "#e67e22", "#9b59b6"];
-        const randomColor = colors[Math.floor(Math.random() * colors.length)];
-        span.style.color = randomColor;
-        const rotation = Math.floor(Math.random() * 31) - 15;
-        span.style.display = "inline-block";
-        span.style.transform = "rotate(" + rotation + "deg)";
+
+      document.getElementById('close-btn').addEventListener('click', closeModal);
+      modal.addEventListener('click', (event) => {
+        if (event.target === event.currentTarget) {
+          closeModal();
+        }
       });
-    }
-    
-    enhanceDifficultWordCloud();
-    enhanceEasyWordCloud();
+      if (modalDialog) {
+        modalDialog.addEventListener('click', (event) => {
+          event.stopPropagation();
+        });
+      }
+
+      document.getElementById('copy-btn').addEventListener('click', async () => {
+        const textarea = document.getElementById('gen-clipboard');
+        textarea.select();
+        textarea.setSelectionRange(0, textarea.value.length);
+        try {
+          await navigator.clipboard.writeText(textarea.value);
+        } catch (err) {
+          document.execCommand('copy');
+        }
+      });
+    })();
   </script>
 {% include 'messages.html' %}
 </body>

--- a/learning/tests/test_analytics.py
+++ b/learning/tests/test_analytics.py
@@ -1,0 +1,122 @@
+import os
+from datetime import date, timedelta
+
+import django
+from django.test import TestCase
+from django.utils import timezone
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "lang_platform.settings")
+django.setup()
+
+from learning.analytics import mode_breakdown, student_mastery, word_stats
+from learning.models import (
+    Assignment,
+    AssignmentAttempt,
+    Class as Classroom,
+    School,
+    Student,
+    User,
+    VocabularyList,
+    VocabularyWord,
+)
+
+
+class AnalyticsBaseTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.school = School.objects.create(name="Test School")
+        cls.teacher = User.objects.create_user(
+            username="teacher",
+            password="password123",
+            email="teacher@example.com",
+            first_name="Teach",
+            last_name="Er",
+            is_teacher=True,
+            school=cls.school,
+        )
+        cls.classroom = Classroom.objects.create(
+            school=cls.school,
+            name="Class A",
+            language="Spanish",
+        )
+        cls.classroom.teachers.add(cls.teacher)
+        cls.vocab_list = VocabularyList.objects.create(
+            name="Core Words",
+            source_language="English",
+            target_language="Spanish",
+            teacher=cls.teacher,
+        )
+        cls.assignment = Assignment.objects.create(
+            name="Assignment 1",
+            class_assigned=cls.classroom,
+            vocab_list=cls.vocab_list,
+            deadline=timezone.now() + timedelta(days=1),
+            target_points=10,
+            teacher=cls.teacher,
+        )
+        cls.word1 = VocabularyWord.objects.create(list=cls.vocab_list, word="hola", translation="hello")
+        cls.word2 = VocabularyWord.objects.create(list=cls.vocab_list, word="adiós", translation="goodbye")
+        cls.student1 = Student.objects.create(
+            school=cls.school,
+            first_name="Alex",
+            last_name="One",
+            year_group=8,
+            date_of_birth=date(2010, 1, 1),
+            username="alex1",
+            password="pass",
+        )
+        cls.student1.classes.add(cls.classroom)
+        cls.student2 = Student.objects.create(
+            school=cls.school,
+            first_name="Bailey",
+            last_name="Two",
+            year_group=8,
+            date_of_birth=date(2010, 2, 2),
+            username="bailey2",
+            password="pass",
+        )
+        cls.student2.classes.add(cls.classroom)
+
+
+class AnalyticsEmptyTests(AnalyticsBaseTestCase):
+    def test_word_stats_empty(self):
+        self.assertEqual(word_stats(self.assignment.id), [])
+
+    def test_mode_breakdown_empty(self):
+        self.assertEqual(mode_breakdown(self.assignment.id), [])
+
+
+class AnalyticsWithAttemptsTests(AnalyticsBaseTestCase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        for _ in range(3):
+            AssignmentAttempt.objects.create(
+                student=cls.student1,
+                assignment=cls.assignment,
+                vocabulary_word=cls.word1,
+                mode="flashcards",
+                is_correct=True,
+            )
+        for _ in range(2):
+            AssignmentAttempt.objects.create(
+                student=cls.student2,
+                assignment=cls.assignment,
+                vocabulary_word=cls.word2,
+                mode="matchup",
+                is_correct=False,
+            )
+        AssignmentAttempt.objects.create(
+            student=cls.student1,
+            assignment=cls.assignment,
+            vocabulary_word=cls.word2,
+            mode="flashcards",
+            is_correct=False,
+        )
+
+    def test_student_mastery_shapes(self):
+        result = student_mastery(self.assignment.id)
+        self.assertIsInstance(result, list)
+        if result:
+            first = result[0]
+            self.assertTrue({"student_id", "name", "words_aced", "needs_practice"}.issubset(first.keys()))

--- a/learning/views_api.py
+++ b/learning/views_api.py
@@ -1,0 +1,369 @@
+import json
+from io import BytesIO
+
+from django.contrib.auth.decorators import login_required
+from django.http import (
+    HttpResponse,
+    HttpResponseBadRequest,
+    HttpResponseForbidden,
+    JsonResponse,
+)
+from django.db.models import Case, Count, Sum, When
+from django.db.models.functions import Coalesce
+from django.shortcuts import get_object_or_404
+from django.utils.text import slugify
+from django.views.decorators.http import require_GET, require_POST
+from xml.sax.saxutils import escape
+
+from datetime import datetime
+from zipfile import ZipFile
+
+from .analytics import (
+    assignment_overview,
+    as_plaintext,
+    build_do_now,
+    build_exit_tickets,
+    build_game_seed,
+    build_sentence_builders,
+    heatmap_data,
+    mode_breakdown,
+    pick_hinge_question,
+    student_mastery,
+    word_stats,
+)
+from .models import Assignment, AssignmentAttempt, AssignmentProgress, Student
+
+
+def _column_letter(index: int) -> str:
+    letters = ""
+    while index > 0:
+        index, remainder = divmod(index - 1, 26)
+        letters = chr(65 + remainder) + letters
+    return letters or "A"
+
+
+def _render_sheet_xml(headers, rows):
+    data_rows = [headers] + rows
+    max_cols = max((len(row) for row in data_rows), default=len(headers) or 1)
+    total_rows = len(data_rows)
+    if max_cols <= 0:
+        max_cols = 1
+    if total_rows <= 0:
+        total_rows = 1
+
+    last_cell = f"{_column_letter(max_cols)}{total_rows}"
+    dimension_ref = f"A1:{last_cell}"
+
+    sheet_rows = []
+    for row_idx, row in enumerate(data_rows, start=1):
+        cells_xml = []
+        for col_idx, value in enumerate(row, start=1):
+            cell_ref = f"{_column_letter(col_idx)}{row_idx}"
+            if value is None or value == "":
+                continue
+            if isinstance(value, (int, float)) and not isinstance(value, bool):
+                cells_xml.append(f"<c r=\"{cell_ref}\"><v>{value}</v></c>")
+            else:
+                text = escape(str(value)).replace("\n", "&#10;")
+                cells_xml.append(
+                    f"<c r=\"{cell_ref}\" t=\"inlineStr\"><is><t>{text}</t></is></c>"
+                )
+        sheet_rows.append(f"<row r=\"{row_idx}\">{''.join(cells_xml)}</row>")
+
+    sheet_data = "".join(sheet_rows)
+    return (
+        "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+        "<worksheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" "
+        "xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\">"
+        f"<dimension ref=\"{dimension_ref}\"/>"
+        "<sheetViews><sheetView workbookViewId=\"0\"/></sheetViews>"
+        "<sheetFormatPr defaultRowHeight=\"15\"/>"
+        f"<sheetData>{sheet_data}</sheetData>"
+        "</worksheet>"
+    )
+
+
+def _build_xlsx(headers, rows, sheet_name="Progress") -> bytes:
+    created = datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+    core_xml = (
+        "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+        "<cp:coreProperties xmlns:cp=\"http://schemas.openxmlformats.org/package/2006/metadata/core-properties\" "
+        "xmlns:dc=\"http://purl.org/dc/elements/1.1/\" xmlns:dcterms=\"http://purl.org/dc/terms/\" "
+        "xmlns:dcmitype=\"http://purl.org/dc/dcmitype/\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">"
+        "<dc:creator>Pavonify</dc:creator>"
+        "<cp:lastModifiedBy>Pavonify</cp:lastModifiedBy>"
+        f"<dcterms:created xsi:type=\"dcterms:W3CDTF\">{created}</dcterms:created>"
+        f"<dcterms:modified xsi:type=\"dcterms:W3CDTF\">{created}</dcterms:modified>"
+        "</cp:coreProperties>"
+    )
+
+    app_xml = (
+        "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+        "<Properties xmlns=\"http://schemas.openxmlformats.org/officeDocument/2006/extended-properties\" "
+        "xmlns:vt=\"http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes\">"
+        "<Application>Microsoft Excel</Application>"
+        "</Properties>"
+    )
+
+    content_types_xml = (
+        "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+        "<Types xmlns=\"http://schemas.openxmlformats.org/package/2006/content-types\">"
+        "<Default Extension=\"rels\" ContentType=\"application/vnd.openxmlformats-package.relationships+xml\"/>"
+        "<Default Extension=\"xml\" ContentType=\"application/xml\"/>"
+        "<Override PartName=\"/xl/workbook.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\"/>"
+        "<Override PartName=\"/xl/worksheets/sheet1.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml\"/>"
+        "<Override PartName=\"/docProps/core.xml\" ContentType=\"application/vnd.openxmlformats-package.core-properties+xml\"/>"
+        "<Override PartName=\"/docProps/app.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.extended-properties+xml\"/>"
+        "<Override PartName=\"/xl/styles.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml\"/>"
+        "</Types>"
+    )
+
+    rels_xml = (
+        "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+        "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">"
+        "<Relationship Id=\"rId1\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument\" Target=\"xl/workbook.xml\"/>"
+        "<Relationship Id=\"rId2\" Type=\"http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties\" Target=\"docProps/core.xml\"/>"
+        "<Relationship Id=\"rId3\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/extended-properties\" Target=\"docProps/app.xml\"/>"
+        "</Relationships>"
+    )
+
+    workbook_xml = (
+        "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+        "<workbook xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" "
+        "xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\">"
+        "<fileVersion appName=\"xl\"/>"
+        "<workbookPr/>"
+        "<bookViews><workbookView/></bookViews>"
+        f"<sheets><sheet name=\"{escape(sheet_name)}\" sheetId=\"1\" r:id=\"rId1\"/></sheets>"
+        "</workbook>"
+    )
+
+    workbook_rels_xml = (
+        "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+        "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">"
+        "<Relationship Id=\"rId1\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet\" Target=\"worksheets/sheet1.xml\"/>"
+        "<Relationship Id=\"rId2\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles\" Target=\"styles.xml\"/>"
+        "</Relationships>"
+    )
+
+    styles_xml = (
+        "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+        "<styleSheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\">"
+        "<fonts count=\"1\"><font><sz val=\"11\"/><color theme=\"1\"/><name val=\"Calibri\"/><family val=\"2\"/></font></fonts>"
+        "<fills count=\"2\"><fill><patternFill patternType=\"none\"/></fill><fill><patternFill patternType=\"gray125\"/></fill></fills>"
+        "<borders count=\"1\"><border><left/><right/><top/><bottom/><diagonal/></border></borders>"
+        "<cellStyleXfs count=\"1\"><xf numFmtId=\"0\" fontId=\"0\" fillId=\"0\" borderId=\"0\"/></cellStyleXfs>"
+        "<cellXfs count=\"1\"><xf numFmtId=\"0\" fontId=\"0\" fillId=\"0\" borderId=\"0\" xfId=\"0\"/></cellXfs>"
+        "<cellStyles count=\"1\"><cellStyle name=\"Normal\" xfId=\"0\" builtinId=\"0\"/></cellStyles>"
+        "</styleSheet>"
+    )
+
+    sheet_xml = _render_sheet_xml(headers, rows)
+
+    buffer = BytesIO()
+    with ZipFile(buffer, "w") as zf:
+        zf.writestr("[Content_Types].xml", content_types_xml)
+        zf.writestr("_rels/.rels", rels_xml)
+        zf.writestr("docProps/core.xml", core_xml)
+        zf.writestr("docProps/app.xml", app_xml)
+        zf.writestr("xl/workbook.xml", workbook_xml)
+        zf.writestr("xl/_rels/workbook.xml.rels", workbook_rels_xml)
+        zf.writestr("xl/styles.xml", styles_xml)
+        zf.writestr("xl/worksheets/sheet1.xml", sheet_xml)
+
+    buffer.seek(0)
+    return buffer.getvalue()
+
+
+def _teacher_can_view(user, assignment: Assignment) -> bool:
+    if not user.is_authenticated or not getattr(user, "is_teacher", False):
+        return False
+    if assignment.teacher_id == user.id:
+        return True
+    if assignment.class_assigned_id is None:
+        return False
+    return assignment.class_assigned.teachers.filter(id=user.id).exists()
+
+
+@login_required
+@require_GET
+def api_word_stats(request, assignment_id):
+    assignment = get_object_or_404(Assignment, id=assignment_id)
+    if not _teacher_can_view(request.user, assignment):
+        return HttpResponseForbidden()
+    return JsonResponse({"results": word_stats(assignment_id)})
+
+
+@login_required
+@require_GET
+def api_mode_breakdown(request, assignment_id):
+    assignment = get_object_or_404(Assignment, id=assignment_id)
+    if not _teacher_can_view(request.user, assignment):
+        return HttpResponseForbidden()
+    return JsonResponse({"results": mode_breakdown(assignment_id)})
+
+
+@login_required
+@require_GET
+def api_student_mastery(request, assignment_id):
+    assignment = get_object_or_404(Assignment, id=assignment_id)
+    if not _teacher_can_view(request.user, assignment):
+        return HttpResponseForbidden()
+    return JsonResponse({"results": student_mastery(assignment_id)})
+
+
+@login_required
+@require_GET
+def api_heatmap(request, assignment_id):
+    assignment = get_object_or_404(Assignment, id=assignment_id)
+    if not _teacher_can_view(request.user, assignment):
+        return HttpResponseForbidden()
+    return JsonResponse(heatmap_data(assignment_id))
+
+
+@login_required
+@require_GET
+def api_overview(request, assignment_id):
+    assignment = get_object_or_404(Assignment, id=assignment_id)
+    if not _teacher_can_view(request.user, assignment):
+        return HttpResponseForbidden()
+    return JsonResponse({"results": assignment_overview(assignment_id)})
+
+
+@login_required
+@require_GET
+def api_export_progress(request, assignment_id):
+    assignment = get_object_or_404(
+        Assignment.objects.select_related("class_assigned"), id=assignment_id
+    )
+    if not _teacher_can_view(request.user, assignment):
+        return HttpResponseForbidden()
+
+    progress_qs = (
+        AssignmentProgress.objects.filter(assignment=assignment)
+        .select_related("student")
+        .order_by("student__last_name", "student__first_name")
+    )
+
+    attempt_stats = (
+        AssignmentAttempt.objects
+        .filter(assignment=assignment)
+        .values("student_id")
+        .annotate(
+            attempts=Count("id"),
+            correct=Coalesce(Sum(Case(When(is_correct=True, then=1), default=0)), 0),
+        )
+    )
+    stats_map = {row["student_id"]: row for row in attempt_stats}
+
+    mastery_map = {
+        entry["student_id"]: entry
+        for entry in student_mastery(assignment_id)
+    }
+
+    student_rows = {}
+    for progress in progress_qs:
+        name = f"{progress.student.first_name} {progress.student.last_name}".strip()
+        student_rows[progress.student_id] = {
+            "name": name or progress.student.username,
+            "username": progress.student.username,
+            "points": progress.points_earned,
+            "completed": "Yes" if progress.completed else "No",
+            "time_spent": str(progress.time_spent) if progress.time_spent else "",
+        }
+
+    # Ensure we include students who have attempts but no progress row yet.
+    missing_ids = [sid for sid in stats_map.keys() if sid not in student_rows]
+    if missing_ids:
+        for student in Student.objects.filter(id__in=missing_ids):
+            name = f"{student.first_name} {student.last_name}".strip()
+            student_rows[student.id] = {
+                "name": name or student.username,
+                "username": student.username,
+                "points": "",
+                "completed": "",
+                "time_spent": "",
+            }
+
+    headers = [
+        "Student",
+        "Username",
+        "Points Earned",
+        "Completed",
+        "Time Spent",
+        "Total Attempts",
+        "Correct",
+        "Accuracy (%)",
+        "Words Aced",
+        "Needs Practice",
+    ]
+    rows = []
+
+    for student_id, row in sorted(
+        student_rows.items(), key=lambda item: item[1]["name"].lower()
+    ):
+        stats = stats_map.get(student_id, {})
+        attempts = stats.get("attempts", 0) or 0
+        correct = stats.get("correct", 0) or 0
+        accuracy = round((correct / attempts * 100), 1) if attempts else 0.0
+
+        mastery = mastery_map.get(student_id, {})
+        words_aced = ", ".join(mastery.get("words_aced", []))
+        needs_practice = ", ".join(mastery.get("needs_practice", []))
+
+        rows.append(
+            [
+                row["name"],
+                row["username"],
+                row.get("points", ""),
+                row.get("completed", ""),
+                row.get("time_spent", ""),
+                attempts,
+                correct,
+                accuracy,
+                words_aced,
+                needs_practice,
+            ]
+        )
+
+    workbook_bytes = _build_xlsx(headers, rows, sheet_name="Progress")
+
+    safe_name = slugify(assignment.name) or f"assignment-{assignment_id}"
+    filename = f"{safe_name}-progress.xlsx"
+
+    response = HttpResponse(
+        workbook_bytes,
+        content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    )
+    response["Content-Disposition"] = f'attachment; filename="{filename}"'
+    return response
+
+
+@login_required
+@require_POST
+def api_generate_activity(request):
+    try:
+        payload = json.loads(request.body.decode())
+        assignment_id = payload["assignment_id"]
+        activity_type = payload["activity_type"]
+    except Exception:
+        return HttpResponseBadRequest("Invalid JSON body")
+
+    assignment = get_object_or_404(Assignment.objects.select_related("class_assigned"), id=assignment_id)
+    if not _teacher_can_view(request.user, assignment):
+        return HttpResponseForbidden()
+
+    if activity_type == "do_now":
+        data = build_do_now(assignment_id)
+    elif activity_type == "exit_tickets":
+        data = build_exit_tickets(assignment_id)
+    elif activity_type == "hinge":
+        data = pick_hinge_question(assignment_id)
+    elif activity_type == "sentences":
+        data = build_sentence_builders(assignment_id)
+    elif activity_type == "game_seed":
+        data = build_game_seed(assignment_id)
+    else:
+        return HttpResponseBadRequest("Unknown activity_type")
+
+    return JsonResponse({"activity": data, "clipboard": as_plaintext(data)})


### PR DESCRIPTION
## Summary
- restyle the assignment analytics action bar and modal while overhauling the feedback tab with digestible metrics, focus lists, and quick-win chips
- extend the analytics view to compute class accuracy, difficult word stats, and focus students for the upgraded feedback experience
- add a lightweight XLSX builder plus an export endpoint and route, and surface a download control on the analytics page
- harden the generated-activity modal so its controls stay clickable by adjusting pointer-event styles, scroll behaviour, and event propagation handling

## Testing
- python manage.py test learning.tests.test_analytics

------
https://chatgpt.com/codex/tasks/task_e_68cb8a04681083259f2e861062cd0876