### PR TITLE
Fix assignment analytics modal interaction handling

### DIFF
--- a/learning/templates/learning/assignment_analytics.html
+++ b/learning/templates/learning/assignment_analytics.html
@@ -160,6 +160,8 @@
       border: 1px solid #ccc;
       padding: 10px;
       font-family: 'Poppins', sans-serif;
+      height: 50vh;
+      resize: vertical;
     }
     #copy-btn,
     #close-btn {
@@ -188,14 +190,26 @@
       background: rgba(0, 0, 0, 0.45);
       z-index: 1200;
       backdrop-filter: blur(2px);
+      padding: 24px 16px;
+      overflow-y: auto;
+      align-items: flex-start;
+      justify-content: center;
+      pointer-events: auto;
+    }
+    #gen-modal * {
+      pointer-events: auto;
     }
     .modal-dialog {
+      width: 100%;
       max-width: 720px;
-      margin: 10vh auto;
       background: #fff;
       padding: 20px;
       border-radius: 16px;
       box-shadow: 0 16px 40px rgba(0,0,0,0.18);
+      position: relative;
+      max-height: 80vh;
+      overflow: auto;
+      pointer-events: auto;
     }
     .feedback-cards {
       display: grid;
@@ -390,13 +404,13 @@
     </div>
 
     <!-- Minimal modal for clipboard -->
-    <div id="gen-modal">
-      <div class="modal-dialog">
+    <div id="gen-modal" aria-hidden="true">
+      <div class="modal-dialog" role="dialog" aria-modal="true" tabindex="-1" aria-labelledby="gen-title">
         <h3 id="gen-title">Generated Activity</h3>
         <textarea id="gen-clipboard" rows="12"></textarea>
         <div style="display:flex; gap:8px; justify-content:flex-end; margin-top:8px;">
-          <button id="copy-btn">Copy to Clipboard</button>
-          <button id="close-btn">Close</button>
+          <button id="copy-btn" type="button">Copy to Clipboard</button>
+          <button id="close-btn" type="button">Close</button>
         </div>
       </div>
     </div>
@@ -666,18 +680,86 @@
         });
       }
 
+      const modalOverlay = document.getElementById('gen-modal');
+      const modalDialog = modalOverlay ? modalOverlay.querySelector('.modal-dialog') : null;
+      const modalTitle = document.getElementById('gen-title');
+      const modalTextarea = document.getElementById('gen-clipboard');
+      const closeButton = document.getElementById('close-btn');
+      const copyButton = document.getElementById('copy-btn');
+      const pageBody = document.body;
+      let previousBodyOverflow = pageBody ? pageBody.style.overflow : '';
+      let lastTriggerButton = null;
+      let copyResetTimer = null;
+
+      function resetCopyButton() {
+        if (copyResetTimer) {
+          window.clearTimeout(copyResetTimer);
+          copyResetTimer = null;
+        }
+        if (copyButton) {
+          copyButton.disabled = false;
+          copyButton.textContent = 'Copy to Clipboard';
+        }
+      }
+
       function openModal(title, text) {
-        document.getElementById('gen-title').textContent = title;
-        document.getElementById('gen-clipboard').value = text;
-        document.getElementById('gen-modal').style.display = 'block';
+        if (modalTitle) {
+          modalTitle.textContent = title;
+        }
+        if (modalTextarea) {
+          modalTextarea.value = text;
+          modalTextarea.scrollTop = 0;
+        }
+        if (modalOverlay) {
+          modalOverlay.style.display = 'flex';
+          modalOverlay.setAttribute('aria-hidden', 'false');
+          modalOverlay.scrollTop = 0;
+        }
+        if (pageBody) {
+          previousBodyOverflow = pageBody.style.overflow;
+          pageBody.style.overflow = 'hidden';
+        }
+        if (modalTextarea) {
+          try {
+            modalTextarea.focus({ preventScroll: true });
+          } catch (err) {
+            modalTextarea.focus();
+          }
+        } else if (modalDialog) {
+          try {
+            modalDialog.focus({ preventScroll: true });
+          } catch (err) {
+            modalDialog.focus();
+          }
+        }
+        document.addEventListener('keydown', handleDocumentKeydown);
       }
 
       function closeModal() {
-        document.getElementById('gen-modal').style.display = 'none';
+        if (modalOverlay) {
+          modalOverlay.style.display = 'none';
+          modalOverlay.setAttribute('aria-hidden', 'true');
+        }
+        if (pageBody) {
+          pageBody.style.overflow = previousBodyOverflow || '';
+        }
+        if (lastTriggerButton) {
+          lastTriggerButton.focus();
+          lastTriggerButton = null;
+        }
+        resetCopyButton();
+        document.removeEventListener('keydown', handleDocumentKeydown);
       }
+
+      const handleDocumentKeydown = (event) => {
+        if (event.key === 'Escape') {
+          closeModal();
+        }
+      };
 
       document.querySelectorAll('.btn-gen').forEach((btn) => {
         btn.addEventListener('click', async () => {
+          lastTriggerButton = btn;
           const type = btn.getAttribute('data-type');
           try {
             const response = await postJSON("{% url 'api_generate_activity' %}", {
@@ -691,23 +773,55 @@
         });
       });
 
-      document.getElementById('close-btn').addEventListener('click', closeModal);
-      document.getElementById('gen-modal').addEventListener('click', (event) => {
-        if (event.target === event.currentTarget) {
-          closeModal();
-        }
-      });
+      if (closeButton) {
+        closeButton.addEventListener('click', closeModal);
+      }
 
-      document.getElementById('copy-btn').addEventListener('click', async () => {
-        const textarea = document.getElementById('gen-clipboard');
-        textarea.select();
-        textarea.setSelectionRange(0, textarea.value.length);
-        try {
-          await navigator.clipboard.writeText(textarea.value);
-        } catch (err) {
-          document.execCommand('copy');
+      if (modalDialog) {
+        modalDialog.addEventListener('click', (event) => {
+          event.stopPropagation();
+        });
+      }
+
+      if (modalOverlay) {
+        modalOverlay.addEventListener('click', (event) => {
+          if (event.target === event.currentTarget) {
+            closeModal();
+          }
+        });
+      }
+
+      function announceCopySuccess() {
+        if (!copyButton) {
+          return;
         }
-      });
+        if (copyResetTimer) {
+          window.clearTimeout(copyResetTimer);
+        }
+        copyButton.disabled = true;
+        copyButton.textContent = 'Copied!';
+        copyResetTimer = window.setTimeout(() => {
+          copyButton.disabled = false;
+          copyButton.textContent = 'Copy to Clipboard';
+          copyResetTimer = null;
+        }, 1600);
+      }
+
+      if (copyButton && modalTextarea) {
+        copyButton.addEventListener('click', async () => {
+          modalTextarea.select();
+          modalTextarea.setSelectionRange(0, modalTextarea.value.length);
+          try {
+            await navigator.clipboard.writeText(modalTextarea.value);
+            announceCopySuccess();
+          } catch (err) {
+            const legacyCopied = document.execCommand('copy');
+            if (legacyCopied !== false) {
+              announceCopySuccess();
+            }
+          }
+        });
+      }
     })();
   </script>
 {% include 'messages.html' %}


### PR DESCRIPTION
## Summary
- allow the assignment analytics quick activity modal to stay interactive by ensuring the dialog captures pointer events and only dismisses when the true backdrop is clicked
- focus the textarea on open and keep the copy button reset plus Escape key listener so clipboard feedback and page scroll state are restored whenever the modal closes

## Testing
- not run (front-end change only)

------
https://chatgpt.com/codex/tasks/task_e_68cb9b0e73a88325b0fc33c757fd0819